### PR TITLE
Create statements in a way that it removes the orphan records when inserting new records

### DIFF
--- a/dumper/channelDataDumper.go
+++ b/dumper/channelDataDumper.go
@@ -21,6 +21,9 @@ func SoftwareChannelTableNames() []string {
 		"rhnchannel",
 		// FIXME This table needs a special treatement to check if channels exists. Inser to into.. select .. were
 		//"rhnchannelcloned", // add only if there are corresponding rows in rhnchannel
+		// FIXME This table needs a special treatement to check if channels exists. Inser to into.. select .. were
+		// shouldn't this table be parte of channel export tables?
+		"suseproductchannel",       // add only if there are corresponding rows in rhnchannel // clean
 		"rhnproductname",
 		"rhnchannelproduct",
 		"rhnreleasechannelmap", // clean
@@ -75,9 +78,7 @@ func ProductsTableNames() []string {
 	return []string{
 		// product data tables
 		"suseproducts",             // clean
-		// FIXME This table needs a special treatement to check if channels exists. Inser to into.. select .. were
-		// shouldn't this table be parte of channel export tables?
-		//"suseproductchannel",       // add only if there are corresponding rows in rhnchannel // clean
+
 		"suseproductextension",     // clean
 		"suseproductsccrepository", // clean
 		"susesccrepository",        // clean

--- a/dumper/channelDataDumper.go
+++ b/dumper/channelDataDumper.go
@@ -10,6 +10,10 @@ import (
 	"github.com/uyuni-project/inter-server-sync/schemareader"
 )
 
+// TablesToClean represents Tables which needs to be cleaned in case on client side there is a record that doesn't exist anymore on master side
+var TablesToClean = []string{"rhnreleasechannelmap", "rhndistchannelmap", "rhnchannelerrata", "rhnchannelpackage", "rhnerratapackage", "rhnerratafile",
+	"rhnerratafilechannel", "rhnerratafilepackage", "rhnerratafilepackagesource", "rhnerratabuglist", "rhnerratacve", "rhnerratakeyword", "susemddata", "susemdkeyword"}
+
 // SoftwareChannelTableNames is the list of names of tables relevant for exporting software channels
 func SoftwareChannelTableNames() []string {
 	return []string{

--- a/dumper/channelDataDumper.go
+++ b/dumper/channelDataDumper.go
@@ -88,7 +88,7 @@ func ProductsTableNames() []string {
 	}
 }
 
-func DumpChannelData(db *sql.DB, channelLabels []string, outputFolder string) DataDumper {
+func DumpChannelData(db *sql.DB, channelLabels []string, outputFolder string) []DataDumper {
 
 	file, err := os.Create(outputFolder + "/sql_statements.sql")
 	if err != nil {

--- a/dumper/dataWritter.go
+++ b/dumper/dataWritter.go
@@ -305,10 +305,17 @@ func filterRowData(value []rowDataStructure, table schemareader.Table) []rowData
 	return value
 }
 func buildQueryToGetExistingRecords(path []string, table schemareader.Table, schemaMetadata map[string]schemareader.Table, channelLabel string) string {
-	mainUniqueColumns := strings.Join(table.UniqueIndexes[table.MainUniqueIndexName].Columns, ",")
+	mainUniqueColumns := ""
+	for _, column := range table.UniqueIndexes[table.MainUniqueIndexName].Columns{
+		if len(mainUniqueColumns) > 0 {
+			mainUniqueColumns = mainUniqueColumns +", "
+		}
+		mainUniqueColumns = mainUniqueColumns + table.Name + "." + column
+	}
+
 	joinsClause := getJoinsClause(path, table, schemaMetadata)
 	whereClause := fmt.Sprintf(`WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = '%s')`, channelLabel)
-	return fmt.Sprintf(`SELECT %s.%s FROM %s %s %s`, table.Name, mainUniqueColumns, table.Name, joinsClause, whereClause)
+	return fmt.Sprintf(`SELECT %s FROM %s %s %s`, mainUniqueColumns, table.Name, joinsClause, whereClause)
 }
 
 func getJoinsClause(path []string, table schemareader.Table, schemaMetadata map[string]schemareader.Table) string {

--- a/dumper/dataWritter.go
+++ b/dumper/dataWritter.go
@@ -323,12 +323,12 @@ func buildQueryToGetExistingRecords(path []string, table schemareader.Table, sch
 		mainUniqueColumns = mainUniqueColumns + table.Name + "." + column
 	}
 
-	joinsClause := getJoinsClause(path, table, schemaMetadata)
+	joinsClause := getJoinsClause(path, schemaMetadata)
 	whereClause := fmt.Sprintf(`WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = '%s')`, channelLabel)
 	return fmt.Sprintf(`SELECT %s FROM %s %s %s`, mainUniqueColumns, table.Name, joinsClause, whereClause)
 }
 
-func getJoinsClause(path []string, table schemareader.Table, schemaMetadata map[string]schemareader.Table) string {
+func getJoinsClause(path []string, schemaMetadata map[string]schemareader.Table) string {
 	var result strings.Builder
 	utils.ReverseArray(path)
 	log.Printf("%s", path)

--- a/dumper/dataWritter.go
+++ b/dumper/dataWritter.go
@@ -333,11 +333,13 @@ func buildQueryToGetExistingRecords(path []string, table schemareader.Table, sch
 
 func getJoinsClause(path []string, schemaMetadata map[string]schemareader.Table) string {
 	var result strings.Builder
-	utils.ReverseArray(path)
-	log.Printf("%s", path)
-	for i := 0; i < len(path)-1; i++ {
-		firstTable := path[i]
-		secondTable := path[i+1]
+	reversePath := make([]string, len(path))
+	copy(reversePath, path)
+	utils.ReverseArray(reversePath)
+	log.Printf("%s", reversePath)
+	for i := 0; i < len(reversePath)-1; i++ {
+		firstTable := reversePath[i]
+		secondTable := reversePath[i+1]
 		reverseRelationLookup := false
 		relationFound := findRelationInfo(schemaMetadata[firstTable].ReferencedBy, secondTable)
 		if relationFound == nil {

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 			log.Fatal("could not start CPU profile: ", err)
 		}
 		defer pprof.StopCPUProfile()
-    }
+	}
 
 	db := schemareader.GetDBconnection(parsedArgs.Config)
 	defer db.Close()
@@ -46,16 +46,20 @@ func main() {
 		tableData := dumper.DumpChannelData(db, channelLabels, outputFolder)
 
 		if parsedArgs.Debug {
-			for path := range tableData.Paths {
-				println(path)
+			for index, channelTableData := range tableData {
+				fmt.Printf("###Processing channe%d...", index)
+				for path := range channelTableData.Paths {
+					println(path)
+				}
+				count := 0
+				for _, value := range channelTableData.TableData {
+					fmt.Printf("%s number inserts: %d \n\t %s keys: %s\n", value.TableName, len(value.Keys),
+						value.TableName, value.Keys)
+					count = count + len(value.Keys)
+				}
+				fmt.Printf("IDS############%d\n\n", count)
 			}
-			count := 0
-			for _, value := range tableData.TableData {
-				fmt.Printf("%s number inserts: %d \n\t %s keys: %s\n", value.TableName, len(value.Keys),
-					value.TableName, value.Keys)
-				count = count + len(value.Keys)
-			}
-			fmt.Printf("IDS############%d\n\n", count)
+
 		}
 	}
 	if parsedArgs.Memprofile != "" {

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -34,21 +34,6 @@ func applyTableFilters(table Table) Table {
 	case "rhnpackagecapability":
 		// pkid: rhn_pkg_capability_id_pk
 		table.PKSequence = "RHN_PKG_CAPABILITY_ID_SEQ"
-	case "suseproductchannel": //FIXME we should try to add a unique constraint to this table instead of this hack
-		// We need to add a virtual unique constraint
-		virtualIndexColumns := []string{"product_id", "channel_id"}
-		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
-		table.MainUniqueIndexName = VirtualIndexName
-	case "susemdkeyword": //FIXME we should try to add a unique constraint to this table instead of this hack
-		// We need to add a virtual unique constraint
-		virtualIndexColumns := []string{"label"}
-		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
-		table.MainUniqueIndexName = VirtualIndexName
-	case "suseupgradepath": //FIXME we should try to add a unique constraint to this table instead of this hack
-		// We need to add a virtual unique constraint
-		virtualIndexColumns := []string{"from_pdid", "to_pdid"}
-		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
-		table.MainUniqueIndexName = VirtualIndexName
 	}
 	return table
 }

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -18,6 +18,13 @@ func applyTableFilters(table Table) Table {
 	case "rhnpackageevr":
 		// constraint: rhn_pe_id_pk
 		table.PKSequence = "rhn_pkg_evr_seq"
+		unexportColumns := make(map[string]bool)
+		unexportColumns["type"] = true
+		table.UnexportColumns = unexportColumns
+		table.UniqueIndexes["rhn_pe_v_r_e_uq"] = UniqueIndex{Name: "rhn_pe_v_r_e_uq",
+			Columns: append(table.UniqueIndexes["rhn_pe_v_r_e_uq"].Columns, "type")}
+		table.UniqueIndexes["rhn_pe_v_r_uq"] = UniqueIndex{Name: "rhn_pe_v_r_uq",
+			Columns: append(table.UniqueIndexes["rhn_pe_v_r_uq"].Columns, "type")}
 	case "rhnpackage":
 		// We need to add a virtual unique constraint
 		table.PKSequence = "RHN_PACKAGE_ID_SEQ"

--- a/schemareader/types.go
+++ b/schemareader/types.go
@@ -2,13 +2,14 @@ package schemareader
 
 // Table represents a DB table to dump
 type Table struct {
-	Name          string
-	Export        bool
-	Columns       []string
-	ColumnIndexes map[string]int
-	PKColumns     map[string]bool
-	PKSequence    string
-	UniqueIndexes map[string]UniqueIndex
+	Name            string
+	Export          bool
+	Columns         []string
+	UnexportColumns map[string]bool
+	ColumnIndexes   map[string]int
+	PKColumns       map[string]bool
+	PKSequence      string
+	UniqueIndexes   map[string]UniqueIndex
 	// a unique index is main when it is the preferred "natural" key
 	MainUniqueIndexName string
 	References          []Reference

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,22 @@
+package utils
+
+import "reflect"
+
+//ReverseArray reverses the array
+func ReverseArray(slice interface{}) {
+	size := reflect.ValueOf(slice).Len()
+	swap := reflect.Swapper(slice)
+	for i, j := 0, size-1; i < j; i, j = i+1, j-1 {
+		swap(i, j)
+	}
+}
+
+// Contains is a helper method to check if a string element exist in the string slice
+func Contains(slice []string, elementToFind string) bool {
+	for _, element := range slice {
+		if elementToFind == element {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR makes use of CTE and the existing UPSERT command in a way that it captures the difference when inserting/updating the tables and then deletes the orphaned records. This is only for these tables which qualify for clean. This is to make the mentioned tables always in sync with the master channels so no orphaned records are left behind.

The syntax structure of the query is as follows.

```sql
WITH 
  new_records_{tableName} AS ( INSERT INTO tableName....ON CONFLICT(keys) RETURNING keys)
, existing_records_{tableName} AS (SELECT keys INNER JOINS (till we reach rhnchannel and then stops) ....WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = `replace-me`)) 

DELETE FROM {tableName} WHERE (keys) IN ( SELECT * FROM existing_records_{channelName} EXCEPT ALL SELECT * FROM insert_and_clean_{channelName});
```

An example query is given below

```sql
WITH new_records_rhnchannelpackage AS (INSERT INTO rhnchannelpackage (channel_id, package_id, created, modified) VALUES ((SELECT id FROM rhnchannel WHERE label = 'clone-2-suse-manager-proxy-2.1-pool-x86_64' limit 1),(SELECT id FROM rhnpackage WHERE name_id = (SELECT id FROM rhnpackagename WHERE name = 'apache2-mod_wsgi' limit 1) and evr_id = (SELECT id FROM rhnpackageevr WHERE epoch is null and release = '5.3.56' and version = '3.3' limit 1) and package_arch_id = (SELECT id FROM rhnpackagearch WHERE label = 'x86_64' limit 1) and checksum_id = (SELECT id FROM rhnchecksum WHERE checksum = 'cf0a13fcbccd6d6d4aa7d47ac641d532a5b2e38e' and checksum_type_id = (SELECT id FROM rhnchecksumtype WHERE label = 'sha1' limit 1) limit 1) and org_id is null limit 1),'2020-11-16 15:11:37.795439+01:00','2020-12-09 18:06:45.426477+01:00')   ON CONFLICT (channel_id, package_id) DO UPDATE SET channel_id = excluded.channel_id,package_id = excluded.package_id,created = excluded.created,modified = excluded.modified RETURNING channel_id,package_id)
,existing_records as (SELECT rhnchannelpackage.channel_id,package_id FROM rhnchannelpackage  INNER JOIN rhnchannel on rhnchannel.id = rhnchannelpackage.channel_id WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = replace-me)) 
DELETE FROM rhnchannelpackage WHERE (channel_id,package_id) IN 
(SELECT * FROM existing_records_channelpackage EXCEPT ALL SELECT * FROM insert_and_clean_rhnchannelpackage);

```

### Notes

- For now, this PR takes care of only for channels related tables. 

- We need to change the way we are creating insert statements, currently if there is more than one channel mentioned that needs to be synced. We
create insert statements in sequence for both channels at once i-e we take a table and then create insert statements for both channels for that table.

What we need to do is process 1 channel at a time which means create all the insert statements for it and then once it's finished then repeat the process for the next one. Note that this will not create much of an overhead performance-wise. 

We need to do this to create the where clause in the following query efficiently so we can restrict the above-mentioned query for only that channel. 
```sql
...WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = replace-me)) 
```

