### PR TITLE
save key as interface instead of string

### DIFF
--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -55,23 +55,24 @@ IterateItemsLoop:
 	return result
 }
 
-func generateKeyIdToMap(data map[string]string) string {
+func generateKeyIdToMap(data map[string]interface{}) string {
 	keyValuesList := make([]string, 0)
 	for _, value := range data {
-		keyValuesList = append(keyValuesList, value)
+		valueStr := fmt.Sprintf("%s", value)
+		keyValuesList = append(keyValuesList, valueStr)
 	}
 	return strings.Join(keyValuesList, "$$")
 }
 
-func extractRowKeyData(table schemareader.Table, itemToProcess processItem) map[string]string {
-	keyColumnData := make(map[string]string)
+func extractRowKeyData(table schemareader.Table, itemToProcess processItem) map[string]interface{} {
+	keyColumnData := make(map[string]interface{})
 	if len(table.PKColumns) > 0 {
 		for pkColumn, _ := range table.PKColumns {
-			keyColumnData[pkColumn] = formatField(itemToProcess.row[table.ColumnIndexes[pkColumn]])
+			keyColumnData[pkColumn] = itemToProcess.row[table.ColumnIndexes[pkColumn]].value
 		}
 	} else {
 		for _, pkColumn := range table.UniqueIndexes[table.MainUniqueIndexName].Columns {
-			keyColumnData[pkColumn] = formatField(itemToProcess.row[table.ColumnIndexes[pkColumn]])
+			keyColumnData[pkColumn] = itemToProcess.row[table.ColumnIndexes[pkColumn]].value
 		}
 	}
 	return keyColumnData

--- a/dumper/types.go
+++ b/dumper/types.go
@@ -1,7 +1,7 @@
 package dumper
 
 type TableKey struct {
-	key map[string]string
+	key map[string]interface{}
 }
 
 type TableDump struct {


### PR DESCRIPTION
table key values to be processed on data dumper was being saved as strings, and for that a method which formats the data according to is type as being used, which surrounds strings with `'`.
This leads to an error of not finding the needed records when dumping data.

With this change, we save the field interface.

Signed-off-by: Ricardo Mateus <rmateus@suse.com>