### PR TITLE
Clean tables refactoring

### DIFF
--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -142,9 +142,11 @@ func shouldFollowReferenceToLink(path []string, currentTable schemareader.Table,
 
 	forcedNavegations := map[string] []string {
 		"rhnchannelfamily": {"rhnpublicchannelfamily"},
-		"rhnchannel": {"susemddata", "suseproductchannel"},
+		"rhnchannel": {"susemddata", "suseproductchannel", "rhnreleasechannelmap", "rhndistchannelmap"},
 		"suseproducts": {"suseproductextension", "suseproductsccrepository"},
 		"rhnpackageevr": {"rhnpackagenevra"},
+		"rhnerrata": {"rhnerratafile"},
+		"rhnerratafile": {"rhnerratafilechannel"},
 	}
 
 	if tableNavigation, ok := forcedNavegations[currentTable.Name]; ok {

--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -19,8 +19,8 @@ func DataCrawler(db *sql.DB, schemaMetadata map[string]schemareader.Table, start
 
 IterateItemsLoop:
 	for len(itemsToProcess) > 0 {
-		itemToProcess := itemsToProcess[0]
-		itemsToProcess = itemsToProcess[1:]
+		itemToProcess := itemsToProcess[len(itemsToProcess)-1]
+		itemsToProcess = itemsToProcess[0:len(itemsToProcess)-1]
 
 		table, tableExists := schemaMetadata[itemToProcess.tableName]
 		if !tableExists {
@@ -50,7 +50,7 @@ IterateItemsLoop:
 
 		newItems := append(followReferencesTo(db, schemaMetadata, table, itemToProcess),
 			followReferencesFrom(db, schemaMetadata, table, itemToProcess)...)
-		itemsToProcess = append(newItems, itemsToProcess...)
+		itemsToProcess = append(itemsToProcess, newItems...)
 
 	}
 	return result

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -13,10 +13,13 @@ import (
 )
 
 // TablesToClean represents Tables which needs to be cleaned in case on client side there is a record that doesn't exist anymore on master side
-// FIXME problematic: rhnerratafile
 var tablesToClean = []string{"rhnreleasechannelmap", "rhndistchannelmap", "rhnchannelerrata", "rhnchannelpackage",
-	"rhnerratapackage", "rhnerratafile", "rhnerratafilechannel", "rhnerratafilepackage", "rhnerratafilepackagesource",
-	"rhnerratabuglist", "rhnerratacve",	"rhnerratakeyword", "susemddata", "susemdkeyword", "suseproductchannel"}
+	"rhnerratapackage",
+	"rhnerratafile",
+	"rhnerratafilechannel", "rhnerratafilepackage", "rhnerratafilepackagesource",
+	"rhnerratabuglist", "rhnerratacve", "rhnerratakeyword", "susemddata",
+	"susemdkeyword",
+	"suseproductchannel"}
 
 // onlyIfParentExistsTables represents Tables for which only records needs to be insterted only if parent record exists
 var onlyIfParentExistsTables = []string{"rhnchannelcloned", "rhnerratacloned", "suseproductchannel"}
@@ -132,8 +135,8 @@ func processAndInsertProducts(db *sql.DB, writer *bufio.Writer) {
 
 func processAndInsertChannels(db *sql.DB, writer *bufio.Writer, options ChannelDumperOptions) {
 
-	// check for duplicated channels andnot export
-	// add option to export "with-childs"
+	// FIXME check for duplicated channels and not export
+	// FIXME add option to export "with-childs"
 
 	schemaMetadata := schemareader.ReadTablesSchema(db, SoftwareChannelTableNames())
 	log.Debug().Msg("channel schema metadata loaded")
@@ -156,7 +159,7 @@ func processChannel(db *sql.DB, writer *bufio.Writer, options ChannelDumperOptio
 
 	cleanWhereClause := fmt.Sprintf(`WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = '%s')`, channelLabel)
 	printOptions := dumper.PrintSqlOptions{
-		TablesToClean: tablesToClean,
+		TablesToClean:            tablesToClean,
 		CleanWhereClause:         cleanWhereClause,
 		OnlyIfParentExistsTables: onlyIfParentExistsTables}
 


### PR DESCRIPTION
separate table clean to a pre-step. 
This was done because of large channels. If we use the "with " clause, we will be loading a lot of data to memory, forcing postgres to use a huge memory footprint.