### PR TITLE
Redirect logs to syslog so is independent from our application as recommended in 12factor application guidelines

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,16 +1,18 @@
 package cmd
 
 import (
+	"log/syslog"
+	"os"
+	"runtime/pprof"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"os"
-	"runtime/pprof"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "inter-server-sync",
-	Short: "Uyuni Inter Server Sync tool",
+	Use:     "inter-server-sync",
+	Short:   "Uyuni Inter Server Sync tool",
 	Version: "0.0.0",
 }
 
@@ -40,16 +42,11 @@ func init() {
 }
 
 func logInit() {
-	Logfile := "/tmp/uyuni_iss_log.json"
-	lf, err := os.OpenFile(Logfile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-	if os.IsNotExist(err) {
-		f, err := os.Create(Logfile)
-		if err != nil {
-			log.Error().Msg("Unable to create logfile")
-		}
-		lf = f
-	}
-	multi := zerolog.MultiLevelWriter(lf, os.Stdout)
+	syslogger, err := syslog.New(syslog.LOG_INFO|syslog.LOG_DEBUG|syslog.LOG_WARNING|syslog.LOG_ERR, "inter-server-sync")
+
+	syslogwriter := zerolog.SyslogLevelWriter(syslogger)
+
+	multi := zerolog.MultiLevelWriter(syslogwriter, os.Stdout)
 	log.Logger = zerolog.New(multi).With().Timestamp().Caller().Logger()
 
 	level, err := zerolog.ParseLevel(logLevel)

--- a/release/hub-iss-logrotate.conf
+++ b/release/hub-iss-logrotate.conf
@@ -1,0 +1,16 @@
+# logrotation file for Inter server sync
+#
+
+/var/log/hub/iss2.log
+{
+    weekly
+    rotate 5
+    copytruncate
+    compress
+    notifempty
+    missingok
+    size=10M
+    postrotate
+        /usr/bin/systemctl reload rsyslog.service > /dev/null
+    endscript
+}

--- a/release/hub-iss-syslogs.conf
+++ b/release/hub-iss-syslogs.conf
@@ -1,0 +1,2 @@
+if $programname == 'inter-server-sync' then /var/log/hub/iss2.log
+& stop


### PR DESCRIPTION
Instead of writing to a file directly, this PR will redirect logs to Syslog, making it independent from our application code. This also goes along the same guidelines as recommended in [12factor](https://12factor.net/logs) application guidelines.

This PR also adds a logrotate config file to handle the rotation of file.

