### PR TITLE
Implement os image export and import

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -62,6 +62,8 @@ func runExport(cmd *cobra.Command, args []string) {
 		OutputFolder:              outputDir,
 		MetadataOnly:              metadataOnly,
 		StartingDate:              validatedDate,
+		OSImages:                  includeImages,
+		Containers:                includeContainers,
 		Orgs:                      orgs,
 	}
 	entityDumper.DumpAllEntities(options)

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -78,29 +78,5 @@ func runExport(cmd *cobra.Command, args []string) {
 	version, product := utils.GetCurrentServerVersion(serverConfig)
 	vf.WriteString("product_name = " + product + "\n" + "version = " + version + "\n")
 
-	if len(channels) > 0 || len(channelWithChildren) > 0 {
-		options := entityDumper.ChannelDumperOptions{
-			ServerConfig:              serverConfig,
-			ChannelLabels:             channels,
-			ChannelWithChildrenLabels: channelWithChildren,
-			OutputFolder:              outputDir,
-			MetadataOnly:              metadataOnly,
-			StartingDate:              validatedDate,
-		}
-		entityDumper.DumpChannelData(options)
-	}
-
-	if includeImages || includeContainers {
-		imageOptions := entityDumper.ImageDumperOptions{
-			ServerConfig: serverConfig,
-			OutputFolder: outputDir,
-			OSImage:      includeImages,
-			Containers:   includeContainers,
-			OrgID:        orgidOnly,
-			StartingDate: validatedDate,
-		}
-		entityDumper.DumpImageData(imageOptions)
-	}
-
 	log.Info().Msgf("Export done. Directory: %s", outputDir)
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -25,7 +25,7 @@ var metadataOnly bool
 var startingDate string
 var includeImages bool
 var includeContainers bool
-var orgidOnly uint
+var orgs []uint
 
 func init() {
 	exportCmd.Flags().StringSliceVar(&channels, "channels", nil, "Channels to be exported")
@@ -36,7 +36,7 @@ func init() {
 	exportCmd.Flags().StringSliceVar(&configChannels, "configChannels", nil, "Configuration Channels to be exported")
 	exportCmd.Flags().BoolVar(&includeImages, "images", false, "Export OS images and associated metadata")
 	exportCmd.Flags().BoolVar(&includeContainers, "containers", false, "Export containers metadata")
-	exportCmd.Flags().UintVar(&orgidOnly, "orgId", 0, "Export only for organization id")
+	exportCmd.Flags().UintSliceVar(&orgs, "orgLimit", nil, "Export only for specified organizations")
 	exportCmd.Args = cobra.NoArgs
 
 	rootCmd.AddCommand(exportCmd)
@@ -62,6 +62,7 @@ func runExport(cmd *cobra.Command, args []string) {
 		OutputFolder:              outputDir,
 		MetadataOnly:              metadataOnly,
 		StartingDate:              validatedDate,
+		Orgs:                      orgs,
 	}
 	entityDumper.DumpAllEntities(options)
 	var versionfile string

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -20,11 +20,6 @@ var importCmd = &cobra.Command{
 	Run:   runImport,
 }
 
-var allowedImports = map[string](string){
-	"CHANNELS": "sql_statements.sql",
-	"IMAGES":   "sql_statements_images.sql",
-}
-
 var importDir string
 var xmlRpcUser string
 var xmlRpcPassword string

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -47,16 +47,12 @@ func runImport(cmd *cobra.Command, args []string) {
 	if fversion != sversion || fproduct != sproduct {
 		log.Panic().Msgf("Wrong version detected. Fileversion = %s ; Serverversion = %s", fversion, sversion)
 	}
-	toImport := validateFolder(absImportDir)
-	if sql, ok := toImport["CHANNELS"]; ok {
-		runPackageFileSync(absImportDir)
-		runImportSql(sql)
-	}
-	if sql, ok := toImport["IMAGES"]; ok {
-		runImageFileSync(absImportDir, serverConfig)
-		runImportSql(sql)
-	}
+	validateFolder(absImportDir)
+	runPackageFileSync(absImportDir)
 
+	runImageFileSync(absImportDir, serverConfig)
+
+	runImportSql(absImportDir)
 	log.Info().Msg("import finished")
 }
 
@@ -80,7 +76,6 @@ func validateFolder(absImportDir string) {
 	if os.IsNotExist(err) {
 		log.Fatal().Err(err).Msg("No usable .sql files found in import directory")
 	}
-	return toImport
 }
 
 func hasConfigChannels(absImportDir string) bool {
@@ -143,7 +138,7 @@ func runImageFileSync(absImportDir string, serverFQDN string) {
 	err = utils.FolderExists(pillarImportDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			log.Warn().Msg("No pillar files to import")
+			log.Info().Msg("No pillar files to import")
 			return
 		} else {
 			log.Fatal().Err(err).Msg("Error reading import folder for pillars")
@@ -163,7 +158,7 @@ func runImportSql(absImportDir string) {
 	log.Info().Msg("Starting SQL import")
 	err := cmd.Run()
 	if err != nil {
-		log.Fatal().Err(err).Msgf("Error running the SQL script %s", source)
+		log.Fatal().Err(err).Msgf("Error running the SQL script")
 	}
 
 	if hasConfigChannels(absImportDir) {

--- a/dumper/crawler_test.go
+++ b/dumper/crawler_test.go
@@ -1,10 +1,11 @@
 package dumper
 
 import (
-	"github.com/uyuni-project/inter-server-sync/schemareader"
-	"github.com/uyuni-project/inter-server-sync/tests"
 	"reflect"
 	"testing"
+
+	"github.com/uyuni-project/inter-server-sync/schemareader"
+	"github.com/uyuni-project/inter-server-sync/tests"
 )
 
 // crawlerTestCase lays down a test scenario for the DataCrawler func
@@ -35,7 +36,7 @@ func TestShouldCreateDataDumper(t *testing.T) {
 	testCase := createDataCrawlerTestCase(graph, root)
 
 	// the data repository expect these statements in the exact same order
-	testCase.repo.Expect("SELECT * FROM root where CUSTOM ;", 1)
+	testCase.repo.Expect("SELECT * FROM root WHERE CUSTOM ;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v31 WHERE id = $1;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v32 WHERE id = $1;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v33 WHERE id = $1;", 1)

--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -60,7 +60,11 @@ IterateItemsLoop:
 }
 
 func initialDataSet(db *sql.DB, startTable schemareader.Table, whereFilter string) []processItem {
-	sql := fmt.Sprintf(`SELECT * FROM %s where %s ;`, startTable.Name, whereFilter)
+	whereClause := ""
+	if len(whereFilter) > 0 {
+		whereClause = fmt.Sprintf("WHERE %s", whereFilter)
+	}
+	sql := fmt.Sprintf(`SELECT * FROM %s %s ;`, startTable.Name, whereClause)
 	rows := sqlUtil.ExecuteQueryWithResults(db, sql)
 	initialDataSet := make([]processItem, 0)
 	for _, row := range rows {
@@ -164,7 +168,7 @@ func shouldFollowReferenceToLink(path []string, currentTable schemareader.Table,
 		}
 	}
 
-	forcedNavegations := map[string][]string{
+	forcedNavigations := map[string][]string{
 		"rhnchannelfamily": {"rhnpublicchannelfamily"},
 		"rhnchannel":       {"susemddata", "suseproductchannel", "rhnreleasechannelmap", "rhndistchannelmap"},
 		"suseproducts":     {"suseproductextension", "suseproductsccrepository"},
@@ -175,7 +179,7 @@ func shouldFollowReferenceToLink(path []string, currentTable schemareader.Table,
 		"rhnconfigfile":    {"rhnconfigrevision"},
 	}
 
-	if tableNavigation, ok := forcedNavegations[currentTable.Name]; ok {
+	if tableNavigation, ok := forcedNavigations[currentTable.Name]; ok {
 		for _, targetNavigationTable := range tableNavigation {
 			if strings.Compare(targetNavigationTable, referencedTable.Name) == 0 {
 				return true

--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -188,7 +188,7 @@ func substitutePrimaryKey(table schemareader.Table, row []sqlUtil.RowDataStructu
 		pkSequence = true
 	}
 	for _, column := range row {
-		if pkSequence && table.PKColumns[column.ColumnName] {
+		if pkSequence && table.PKColumns[column.ColumnName] && len(table.PKColumns) == 1 {
 			column.ColumnType = "SQL"
 			column.Value = fmt.Sprintf("SELECT nextval('%s')", table.PKSequence)
 			rowResult = append(rowResult, column)

--- a/dumper/dumpAllTableData.go
+++ b/dumper/dumpAllTableData.go
@@ -4,23 +4,21 @@ import (
 	"bufio"
 	"database/sql"
 	"fmt"
+	"strings"
+
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/inter-server-sync/schemareader"
 	"github.com/uyuni-project/inter-server-sync/sqlUtil"
-	"strings"
 )
 
 func DumpAllTablesData(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table,
 	startingTables []schemareader.Table, whereFilterClause func(table schemareader.Table) string, onlyIfParentExistsTables []string) {
 
-	processedTables := make(map[string]bool)
 	// exporting from the starting tables.
-	for _, startingTable := range startingTables{
-		processedTables = processTableDataWithLinks(db, writer, schemaMetadata, startingTable, whereFilterClause, processedTables, make([]string, 0), onlyIfParentExistsTables)
-	}
+	processedTables := DumpReachableTablesData(db, writer, schemaMetadata, startingTables, whereFilterClause, onlyIfParentExistsTables, make(map[string]bool))
 	// Export tables not visited when exporting the starting tables
-	for schemaTableName, schemaTable := range schemaMetadata{
-		if !schemaTable.Export{
+	for schemaTableName, schemaTable := range schemaMetadata {
+		if !schemaTable.Export {
 			continue
 		}
 		_, ok := processedTables[schemaTableName]
@@ -31,9 +29,23 @@ func DumpAllTablesData(db *sql.DB, writer *bufio.Writer, schemaMetadata map[stri
 	}
 }
 
+func DumpReachableTablesData(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table,
+	startingTables []schemareader.Table, whereFilterClause func(table schemareader.Table) string, onlyIfParentExistsTables []string, processedTables map[string]bool) map[string]bool {
+
+	for _, startingTable := range startingTables {
+		_, ok := processedTables[startingTable.Name]
+		if ok {
+			continue
+		}
+		processedTables = processTableDataWithLinks(db, writer, schemaMetadata, startingTable, whereFilterClause, processedTables, make([]string, 0), onlyIfParentExistsTables)
+	}
+
+	return processedTables
+}
+
 func processTableDataWithLinks(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, table schemareader.Table,
-	whereFilterClause func(table schemareader.Table) string, processedTables map[string]bool, path []string, onlyIfParentExistsTables[]string) map[string]bool {
-	log.Trace().Msgf("%s", "Processing table: " + table.Name)
+	whereFilterClause func(table schemareader.Table) string, processedTables map[string]bool, path []string, onlyIfParentExistsTables []string) map[string]bool {
+	log.Trace().Msgf("Processing table: %s", table.Name)
 	_, tableProcessed := processedTables[table.Name]
 	currentTable := schemaMetadata[table.Name]
 	if tableProcessed || !currentTable.Export {
@@ -47,7 +59,7 @@ func processTableDataWithLinks(db *sql.DB, writer *bufio.Writer, schemaMetadata 
 		if !ok || !tableReference.Export {
 			continue
 		}
-		log.Trace().Msgf("%s", "Table processed: " + table.Name)
+		log.Trace().Msgf("Table processed: %s", table.Name)
 		processTableDataWithLinks(db, writer, schemaMetadata, tableReference, whereFilterClause, processedTables, path, onlyIfParentExistsTables)
 
 	}
@@ -71,6 +83,7 @@ func processTableDataWithLinks(db *sql.DB, writer *bufio.Writer, schemaMetadata 
 func exportAllTableData(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, table schemareader.Table,
 	whereFilterClause func(table schemareader.Table) string, onlyIfParentExistsTables []string) {
 
+	log.Trace().Msgf("Exporting data for table %s", table.Name)
 	formattedColumns := strings.Join(table.Columns, ", ")
 	sql := fmt.Sprintf(`SELECT %s FROM %s %s;`, formattedColumns, table.Name, whereFilterClause(table))
 	rows := sqlUtil.ExecuteQueryWithResults(db, sql)

--- a/dumper/osImageDumper/osImageDumper.go
+++ b/dumper/osImageDumper/osImageDumper.go
@@ -14,7 +14,7 @@ var serverDataFolder = "/srv/www/os-images/"
 //FIXME: we have no relation from db tables to actial data so for now copy content of serverDataFolder
 //func DumpOsImages(db *sql.DB, schemaMetadata map[string]schemareader.Table, data dumper.DataDumper, outputFolder string) {
 func DumpOsImages(outputFolder string, orgIds []uint) {
-	log.Debug().Msg("Image data dump")
+	log.Debug().Msg("Images data dump")
 
 	imagesDir, err := os.Open(serverDataFolder)
 	if err != nil {
@@ -40,15 +40,27 @@ func DumpOsImages(outputFolder string, orgIds []uint) {
 
 				for _, image := range orgDirInfo {
 					if image.Type().IsRegular() {
-						var imagePath = path.Join(orgDirPath, image.Name())
-						log.Trace().Msgf("Copying image %s", imagePath)
-						_, err := dumper.Copy(imagePath, path.Join(outputFolder, org.Name(), image.Name()))
-						if err != nil {
-							log.Fatal().Err(err)
-						}
+						DumpOsImage(path.Join(outputFolder, org.Name(), image.Name()), path.Join(orgDirPath, image.Name()))
 					}
 				}
 			}
 		}
 	}
+}
+
+func DumpOsImage(outputFolder string, source string) {
+	log.Trace().Msgf("Copying image %s to %s", source, outputFolder)
+	_, err := dumper.Copy(source, outputFolder)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+}
+
+func GetImagePathForImage(filepath string, org_id string, prefixOpt ...string) string {
+	prefix := serverDataFolder
+	if len(prefixOpt) > 0 {
+		prefix = prefixOpt[0]
+	}
+
+	return path.Join(prefix, org_id, filepath)
 }

--- a/dumper/osImageDumper/osImageDumper.go
+++ b/dumper/osImageDumper/osImageDumper.go
@@ -13,7 +13,7 @@ var serverDataFolder = "/srv/www/os-images/"
 
 //FIXME: we have no relation from db tables to actial data so for now copy content of serverDataFolder
 //func DumpOsImages(db *sql.DB, schemaMetadata map[string]schemareader.Table, data dumper.DataDumper, outputFolder string) {
-func DumpOsImages(outputFolder string, orgId uint) {
+func DumpOsImages(outputFolder string, orgIds []uint) {
 	log.Debug().Msg("Image data dump")
 
 	imagesDir, err := os.Open(serverDataFolder)
@@ -23,23 +23,29 @@ func DumpOsImages(outputFolder string, orgId uint) {
 	defer imagesDir.Close()
 	orgDirInfo, err := imagesDir.ReadDir(-1)
 
-	for _, org := range orgDirInfo {
-		if org.Type().IsDir() && (orgId == 0 || org.Name() == fmt.Sprint(orgId)) {
-			var orgDirPath = path.Join(serverDataFolder, org.Name())
-			orgDir, err := os.Open(orgDirPath)
-			if err != nil {
-				log.Fatal().Err(err)
-			}
-			defer orgDir.Close()
-			orgDirInfo, err := orgDir.ReadDir(-1)
+	if len(orgIds) == 0 {
+		orgIds = []uint{0}
+	}
 
-			for _, image := range orgDirInfo {
-				if image.Type().IsRegular() {
-					var imagePath = path.Join(orgDirPath, image.Name())
-					log.Trace().Msgf("Copying image %s", imagePath)
-					_, err := dumper.Copy(imagePath, path.Join(outputFolder, org.Name(), image.Name()))
-					if err != nil {
-						log.Fatal().Err(err)
+	for _, org := range orgDirInfo {
+		for _, orgId := range orgIds {
+			if org.Type().IsDir() && (orgId == 0 || org.Name() == fmt.Sprint(orgId)) {
+				var orgDirPath = path.Join(serverDataFolder, org.Name())
+				orgDir, err := os.Open(orgDirPath)
+				if err != nil {
+					log.Fatal().Err(err)
+				}
+				defer orgDir.Close()
+				orgDirInfo, err := orgDir.ReadDir(-1)
+
+				for _, image := range orgDirInfo {
+					if image.Type().IsRegular() {
+						var imagePath = path.Join(orgDirPath, image.Name())
+						log.Trace().Msgf("Copying image %s", imagePath)
+						_, err := dumper.Copy(imagePath, path.Join(outputFolder, org.Name(), image.Name()))
+						if err != nil {
+							log.Fatal().Err(err)
+						}
 					}
 				}
 			}

--- a/dumper/osImageDumper/osImageDumper.go
+++ b/dumper/osImageDumper/osImageDumper.go
@@ -1,0 +1,48 @@
+package osImageDumper
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/inter-server-sync/dumper"
+)
+
+var serverDataFolder = "/srv/www/os-images/"
+
+//FIXME: we have no relation from db tables to actial data so for now copy content of serverDataFolder
+//func DumpOsImages(db *sql.DB, schemaMetadata map[string]schemareader.Table, data dumper.DataDumper, outputFolder string) {
+func DumpOsImages(outputFolder string, orgId uint) {
+	log.Debug().Msg("Image data dump")
+
+	imagesDir, err := os.Open(serverDataFolder)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	defer imagesDir.Close()
+	orgDirInfo, err := imagesDir.ReadDir(-1)
+
+	for _, org := range orgDirInfo {
+		if org.Type().IsDir() && (orgId == 0 || org.Name() == fmt.Sprint(orgId)) {
+			var orgDirPath = path.Join(serverDataFolder, org.Name())
+			orgDir, err := os.Open(orgDirPath)
+			if err != nil {
+				log.Fatal().Err(err)
+			}
+			defer orgDir.Close()
+			orgDirInfo, err := orgDir.ReadDir(-1)
+
+			for _, image := range orgDirInfo {
+				if image.Type().IsRegular() {
+					var imagePath = path.Join(orgDirPath, image.Name())
+					log.Trace().Msgf("Copying image %s", imagePath)
+					_, err := dumper.Copy(imagePath, path.Join(outputFolder, org.Name(), image.Name()))
+					if err != nil {
+						log.Fatal().Err(err)
+					}
+				}
+			}
+		}
+	}
+}

--- a/dumper/pillarDumper/pillarDumper.go
+++ b/dumper/pillarDumper/pillarDumper.go
@@ -1,0 +1,96 @@
+package pillarDumper
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/inter-server-sync/dumper"
+	"github.com/uyuni-project/inter-server-sync/utils"
+)
+
+var serverDataDir = "/srv/susemanager/pillar_data/"
+var replacePattern = "{SERVER_FQDN}"
+
+func DumpImagePillars(outputDir string, orgId uint, serverConfig string) {
+	log.Debug().Msgf("Dumping pillars to %s", outputDir)
+	fqdn := utils.GetCurrentServerFQDN(serverConfig)
+
+	sourceDir := filepath.Join(serverDataDir, "images")
+	orgDir, err := os.Open(sourceDir)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	defer orgDir.Close()
+	orgDirInfo, err := orgDir.ReadDir(-1)
+
+	for _, org := range orgDirInfo {
+		if org.Type().IsDir() && (orgId == 0 || org.Name() == fmt.Sprintf("org%d", orgId)) {
+			DumpPillars(path.Join(sourceDir, org.Name()), path.Join(outputDir, org.Name()), fqdn, replacePattern)
+		}
+	}
+}
+
+func DumpPillars(sourceDir, outputDir, sourceFQDN, targetFQDN string) {
+	log.Trace().Msgf("Pillar dump for %s, replacing FQDN %s", sourceDir, sourceFQDN)
+
+	pillarDir, err := os.Open(sourceDir)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	defer pillarDir.Close()
+	pillarDirInfo, err := pillarDir.ReadDir(-1)
+
+	for _, pillar := range pillarDirInfo {
+		if pillar.Type().IsRegular() {
+			pillarFilePath := path.Join(sourceDir, pillar.Name())
+			pillarTargetPath := path.Join(outputDir, pillar.Name())
+			log.Trace().Msgf("Parsing and copying pillar from %s to %s", pillarFilePath, pillarTargetPath)
+
+			_, err := dumper.ModifyCopy(pillarFilePath,
+				pillarTargetPath,
+				sourceFQDN, targetFQDN)
+			if err != nil {
+				log.Fatal().Err(err)
+			}
+			os.Chmod(pillarTargetPath, 0640)
+			cmd := exec.Command("chown", "salt:susemanager", pillarTargetPath)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Run()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Error processing image pillar files")
+			}
+		}
+	}
+}
+
+func ImportImagePillars(sourceDir string, serverConfig string) {
+	log.Debug().Msgf("Importing image pillars from %s", sourceDir)
+	fqdn := utils.GetCurrentServerFQDN(serverConfig)
+	orgDir, err := os.Open(sourceDir)
+	if err != nil {
+		log.Fatal().Err(err)
+	}
+	defer orgDir.Close()
+	orgDirInfo, err := orgDir.ReadDir(-1)
+
+	for _, org := range orgDirInfo {
+		if org.Type().IsDir() {
+			targetDir := path.Join(serverDataDir, "images", org.Name())
+			DumpPillars(path.Join(sourceDir, org.Name()), targetDir, replacePattern, fqdn)
+
+			cmd := exec.Command("chown", "salt:susemanager", targetDir)
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			err = cmd.Run()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Error importing image pillar files")
+
+			}
+		}
+	}
+}

--- a/dumper/pillarDumper/pillarDumper.go
+++ b/dumper/pillarDumper/pillarDumper.go
@@ -15,7 +15,7 @@ import (
 var serverDataDir = "/srv/susemanager/pillar_data/"
 var replacePattern = "{SERVER_FQDN}"
 
-func DumpImagePillars(outputDir string, orgId uint, serverConfig string) {
+func DumpImagePillars(outputDir string, orgIds []uint, serverConfig string) {
 	log.Debug().Msgf("Dumping pillars to %s", outputDir)
 	fqdn := utils.GetCurrentServerFQDN(serverConfig)
 
@@ -27,10 +27,18 @@ func DumpImagePillars(outputDir string, orgId uint, serverConfig string) {
 	defer orgDir.Close()
 	orgDirInfo, err := orgDir.ReadDir(-1)
 
+	// If orgIds is empty, set it to 0 so all orgs would be exported
+	if len(orgIds) == 0 {
+		orgIds = []uint{0}
+	}
+
 	for _, org := range orgDirInfo {
-		if org.Type().IsDir() && (orgId == 0 || org.Name() == fmt.Sprintf("org%d", orgId)) {
-			DumpPillars(path.Join(sourceDir, org.Name()), path.Join(outputDir, org.Name()), fqdn, replacePattern)
+		for _, orgId := range orgIds {
+			if org.Type().IsDir() && (orgId == 0 || org.Name() == fmt.Sprintf("org%d", orgId)) {
+				DumpPillars(path.Join(sourceDir, org.Name()), path.Join(outputDir, org.Name()), fqdn, replacePattern)
+			}
 		}
+
 	}
 }
 

--- a/dumper/utils.go
+++ b/dumper/utils.go
@@ -1,0 +1,68 @@
+package dumper
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func Copy(src, dst string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	source, err := os.Open(src)
+	if err != nil {
+		return 0, err
+	}
+	defer source.Close()
+
+	destination, err := create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+	nBytes, err := io.Copy(destination, source)
+	return nBytes, err
+}
+
+func ModifyCopy(src, dst, pattern, replace string) (int64, error) {
+	sourceFileStat, err := os.Stat(src)
+	if err != nil {
+		return 0, err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return 0, fmt.Errorf("%s is not a regular file", src)
+	}
+
+	input, err := os.ReadFile(src)
+	if err != nil {
+		return 0, err
+	}
+
+	output := strings.ReplaceAll(string(input), pattern, replace)
+
+	destination, err := create(dst)
+	if err != nil {
+		return 0, err
+	}
+	defer destination.Close()
+
+	nBytes, err := destination.Write([]byte(output))
+	return int64(nBytes), err
+}
+
+func create(p string) (*os.File, error) {
+	if err := os.MkdirAll(filepath.Dir(p), 0770); err != nil {
+		return nil, err
+	}
+	return os.Create(p)
+}

--- a/dumper/writer_test.go
+++ b/dumper/writer_test.go
@@ -2,12 +2,13 @@ package dumper
 
 import (
 	"fmt"
-	"github.com/uyuni-project/inter-server-sync/schemareader"
-	"github.com/uyuni-project/inter-server-sync/sqlUtil"
-	"github.com/uyuni-project/inter-server-sync/tests"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/uyuni-project/inter-server-sync/schemareader"
+	"github.com/uyuni-project/inter-server-sync/sqlUtil"
+	"github.com/uyuni-project/inter-server-sync/tests"
 )
 
 // writerTestCase is a general object for each dumper's recursive method
@@ -106,30 +107,30 @@ func TestPrintCleanTables(t *testing.T) {
 		PrintSqlOptions{TablesToClean: keys},
 	)
 
-	testCase.repo.Expect("Select * FROM root WHERE (id) IN (SELECT root.id FROM root  );", 1)
+	testCase.repo.Expect("SELECT * FROM root WHERE (id) IN (SELECT root.id FROM root  );", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v11 WHERE id = $1;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v12 WHERE id = $1;", 1)
-	testCase.repo.Expect("Select * FROM v11 WHERE (id) IN (SELECT v11.id FROM v11  "+
+	testCase.repo.Expect("SELECT * FROM v11 WHERE (id) IN (SELECT v11.id FROM v11  "+
 		"INNER JOIN root on root.fk_id = v11.id );", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v15 WHERE id = $1;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v16 WHERE id = $1;", 1)
-	testCase.repo.Expect("Select * FROM v15 WHERE (id) IN (SELECT v15.id FROM v15  "+
+	testCase.repo.Expect("SELECT * FROM v15 WHERE (id) IN (SELECT v15.id FROM v15  "+
 		"INNER JOIN v11 on v11.fk_id = v15.id "+
 		"INNER JOIN root on root.fk_id = v11.id );", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v14 WHERE id = $1;", 1)
-	testCase.repo.Expect("Select * FROM v14 WHERE (id) IN (SELECT v14.id FROM v14  "+
+	testCase.repo.Expect("SELECT * FROM v14 WHERE (id) IN (SELECT v14.id FROM v14  "+
 		"INNER JOIN v15 on v15.fk_id = v14.id "+
 		"INNER JOIN v11 on v11.fk_id = v15.id "+
 		"INNER JOIN root on root.fk_id = v11.id );", 1)
-	testCase.repo.Expect("Select * FROM v16 WHERE (id) IN (SELECT v16.id FROM v16  "+
+	testCase.repo.Expect("SELECT * FROM v16 WHERE (id) IN (SELECT v16.id FROM v16  "+
 		"INNER JOIN v14 on v14.fk_id = v16.id "+
 		"INNER JOIN v15 on v15.fk_id = v14.id "+
 		"INNER JOIN v11 on v11.fk_id = v15.id "+
 		"INNER JOIN root on root.fk_id = v11.id );", 1)
-	testCase.repo.Expect("Select * FROM v12 WHERE (id) IN (SELECT v12.id FROM v12  "+
+	testCase.repo.Expect("SELECT * FROM v12 WHERE (id) IN (SELECT v12.id FROM v12  "+
 		"INNER JOIN root on root.fk_id = v12.id );", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v13 WHERE id = $1;", 1)
-	testCase.repo.Expect("Select * FROM v13 WHERE (id) IN (SELECT v13.id FROM v13  "+
+	testCase.repo.Expect("SELECT * FROM v13 WHERE (id) IN (SELECT v13.id FROM v13  "+
 		"INNER JOIN v12 on v12.fk_id = v13.id "+
 		"INNER JOIN root on root.fk_id = v12.id );", 1)
 
@@ -139,26 +140,26 @@ func TestPrintCleanTables(t *testing.T) {
 			"DELETE FROM root WHERE (id) IN (SELECT root.id FROM root  );" +
 			"\n" +
 			"INSERT INTO root (id, fk_id)\t" +
-			"select (SELECT id FROM v12 WHERE id = '0001' limit 1),'0001'  " +
-			"where  not exists (select 1 from root where  id = (SELECT id FROM v12 WHERE id = '0001' limit 1))" +
-			" and exists (SELECT id FROM v12 WHERE id = '0001' limit 1);" +
+			"SELECT (SELECT id FROM v12 WHERE id = '0001' LIMIT 1),'0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM root WHERE  id = (SELECT id FROM v12 WHERE id = '0001' LIMIT 1))" +
+			" AND EXISTS (SELECT id FROM v12 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v11 WHERE (id) IN (SELECT v11.id FROM v11  INNER JOIN root on root.fk_id = v11.id );" +
 			"\n" +
 			"INSERT INTO v11 (id, fk_id)\t" +
-			"select (SELECT id FROM v16 WHERE id = '0001' limit 1),'0001'  " +
-			"where  not exists (select 1 from v11 where  id = (SELECT id FROM v16 WHERE id = '0001' limit 1)) " +
-			"and exists (SELECT id FROM v16 WHERE id = '0001' limit 1);" +
+			"SELECT (SELECT id FROM v16 WHERE id = '0001' LIMIT 1),'0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v11 WHERE  id = (SELECT id FROM v16 WHERE id = '0001' LIMIT 1)) " +
+			"AND EXISTS (SELECT id FROM v16 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v15 WHERE (id) IN " +
 			"(SELECT v15.id FROM v15  INNER JOIN v11 on v11.fk_id = v15.id INNER JOIN root on root.fk_id = v11.id );" +
 			"\n" +
 			"INSERT INTO v15 (id, fk_id)\t" +
-			"select (SELECT id FROM v14 WHERE id = '0001' limit 1),'0001'  " +
-			"where  not exists (select 1 from v15 where  id = (SELECT id FROM v14 WHERE id = '0001' limit 1)) " +
-			"and exists (SELECT id FROM v14 WHERE id = '0001' limit 1);" +
+			"SELECT (SELECT id FROM v14 WHERE id = '0001' LIMIT 1),'0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v15 WHERE  id = (SELECT id FROM v14 WHERE id = '0001' LIMIT 1)) " +
+			"AND EXISTS (SELECT id FROM v14 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v14 WHERE (id) IN " +
@@ -168,9 +169,9 @@ func TestPrintCleanTables(t *testing.T) {
 			"INNER JOIN root on root.fk_id = v11.id );" +
 			"\n" +
 			"INSERT INTO v14 (id, fk_id)\t" +
-			"select (SELECT id FROM v16 WHERE id = '0001' limit 1),'0001'  " +
-			"where  not exists (select 1 from v14 where  id = (SELECT id FROM v16 WHERE id = '0001' limit 1)) " +
-			"and exists (SELECT id FROM v16 WHERE id = '0001' limit 1);" +
+			"SELECT (SELECT id FROM v16 WHERE id = '0001' LIMIT 1),'0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v14 WHERE  id = (SELECT id FROM v16 WHERE id = '0001' LIMIT 1)) " +
+			"AND EXISTS (SELECT id FROM v16 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v16 WHERE (id) IN " +
@@ -181,9 +182,9 @@ func TestPrintCleanTables(t *testing.T) {
 			"INNER JOIN root on root.fk_id = v11.id );" +
 			"\n" +
 			"INSERT INTO v16 (id, fk_id)\t" +
-			"select '0001','0001'  " +
-			"where  not exists (select 1 from v16 where  id = '0001') " +
-			"and ;" +
+			"SELECT '0001','0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v16 WHERE  id = '0001') " +
+			"AND ;" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v12 WHERE (id) IN " +
@@ -191,9 +192,9 @@ func TestPrintCleanTables(t *testing.T) {
 			"INNER JOIN root on root.fk_id = v12.id );" +
 			"\n" +
 			"INSERT INTO v12 (id, fk_id)\t" +
-			"select (SELECT id FROM v13 WHERE id = '0001' limit 1),'0001'  " +
-			"where  not exists (select 1 from v12 where  id = (SELECT id FROM v13 WHERE id = '0001' limit 1)) " +
-			"and exists (SELECT id FROM v13 WHERE id = '0001' limit 1);" +
+			"SELECT (SELECT id FROM v13 WHERE id = '0001' LIMIT 1),'0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v12 WHERE  id = (SELECT id FROM v13 WHERE id = '0001' LIMIT 1)) " +
+			"AND EXISTS (SELECT id FROM v13 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v13 WHERE (id) IN " +
@@ -202,9 +203,9 @@ func TestPrintCleanTables(t *testing.T) {
 			"INNER JOIN root on root.fk_id = v12.id );" +
 			"\n" +
 			"INSERT INTO v13 (id, fk_id)\t" +
-			"select (SELECT id FROM v14 WHERE id = '0001' limit 1),'0001'  " +
-			"where  not exists (select 1 from v13 where  id = (SELECT id FROM v14 WHERE id = '0001' limit 1)) " +
-			"and exists (SELECT id FROM v14 WHERE id = '0001' limit 1);" +
+			"SELECT (SELECT id FROM v14 WHERE id = '0001' LIMIT 1),'0001' " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v13 WHERE  id = (SELECT id FROM v14 WHERE id = '0001' LIMIT 1)) " +
+			"AND EXISTS (SELECT id FROM v14 WHERE id = '0001' LIMIT 1);" +
 			"\n",
 	}
 
@@ -260,17 +261,17 @@ func TestPrintTableData(t *testing.T) {
 	testCase := createTestCase(graph, root, PrintSqlOptions{PostOrderCallback: createCallback()})
 
 	// the data repository expect these statements in the exact same order
-	testCase.repo.Expect("SELECT id, fk_id FROM v26 WHERE (id) in (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v24 WHERE (id) in (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM v26 WHERE (id) IN (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM v24 WHERE (id) IN (('0001'));", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v25 WHERE id = $1;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v26 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v25 WHERE (id) in (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM v25 WHERE (id) IN (('0001'));", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v24 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v21 WHERE (id) in (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v23 WHERE (id) in (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v22 WHERE (id) in (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM v21 WHERE (id) IN (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM v23 WHERE (id) IN (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM v22 WHERE (id) IN (('0001'));", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v23 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM root WHERE (id) in (('0001'));", 1)
+	testCase.repo.Expect("SELECT id, fk_id FROM root WHERE (id) IN (('0001'));", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v21 WHERE id = $1;", 1)
 	testCase.repo.Expect("SELECT id, fk_id FROM v22 WHERE id = $1;", 1)
 

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"database/sql"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -11,6 +12,7 @@ import (
 	"github.com/uyuni-project/inter-server-sync/dumper/packageDumper"
 	"github.com/uyuni-project/inter-server-sync/schemareader"
 	"github.com/uyuni-project/inter-server-sync/sqlUtil"
+	"github.com/uyuni-project/inter-server-sync/utils"
 )
 
 // TablesToClean represents Tables which needs to be cleaned in case on client side there is a record that doesn't exist anymore on master side

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"database/sql"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/rs/zerolog/log"
@@ -12,7 +11,6 @@ import (
 	"github.com/uyuni-project/inter-server-sync/dumper/packageDumper"
 	"github.com/uyuni-project/inter-server-sync/schemareader"
 	"github.com/uyuni-project/inter-server-sync/sqlUtil"
-	"github.com/uyuni-project/inter-server-sync/utils"
 )
 
 // TablesToClean represents Tables which needs to be cleaned in case on client side there is a record that doesn't exist anymore on master side

--- a/entityDumper/dumper.go
+++ b/entityDumper/dumper.go
@@ -2,9 +2,10 @@ package entityDumper
 
 import (
 	"bufio"
+	"os"
+
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/inter-server-sync/schemareader"
-	"os"
 )
 
 func DumpAllEntities(options DumperOptions) {
@@ -31,6 +32,10 @@ func DumpAllEntities(options DumperOptions) {
 		db := schemareader.GetDBconnection(options.ServerConfig)
 		defer db.Close()
 		processConfigs(db, bufferWriter, options)
+	}
+
+	if options.OSImages || options.Containers {
+		dumpImageData(options)
 	}
 
 	bufferWriter.WriteString("COMMIT;\n")

--- a/entityDumper/dumper.go
+++ b/entityDumper/dumper.go
@@ -21,21 +21,19 @@ func DumpAllEntities(options DumperOptions) {
 	bufferWriter := bufio.NewWriter(file)
 	defer bufferWriter.Flush()
 
+	db := schemareader.GetDBconnection(options.ServerConfig)
+	defer db.Close()
 	bufferWriter.WriteString("BEGIN;\n")
 	if len(options.ChannelLabels) > 0 {
-		db := schemareader.GetDBconnection(options.ServerConfig)
-		defer db.Close()
 		processAndInsertProducts(db, bufferWriter)
 		processAndInsertChannels(db, bufferWriter, options)
 	}
 	if len(options.ConfigLabels) > 0 {
-		db := schemareader.GetDBconnection(options.ServerConfig)
-		defer db.Close()
 		processConfigs(db, bufferWriter, options)
 	}
 
 	if options.OSImages || options.Containers {
-		dumpImageData(options)
+		dumpImageData(db, bufferWriter, options)
 	}
 
 	bufferWriter.WriteString("COMMIT;\n")

--- a/entityDumper/imageDataDumper.go
+++ b/entityDumper/imageDataDumper.go
@@ -1,0 +1,219 @@
+package entityDumper
+
+import (
+	"bufio"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/inter-server-sync/dumper"
+	"github.com/uyuni-project/inter-server-sync/dumper/osImageDumper"
+	"github.com/uyuni-project/inter-server-sync/dumper/pillarDumper"
+	"github.com/uyuni-project/inter-server-sync/schemareader"
+	"github.com/uyuni-project/inter-server-sync/sqlUtil"
+)
+
+// TablesToClean represents Tables which needs to be cleaned in case on client side there is a record that doesn't exist anymore on master side
+var tablesToClean_images = []string{
+	"suseimageinfochannel",
+}
+
+/*
+    Activation keys are not exported - they are managed by uyunit formulas and/or XMLRPC/salt calls
+
+	If correct activation key is not present, OS images, particularly saltboot images, may not finish bootstrap correctly
+*/
+var imagesTableNames = []string{
+	// stores
+	"suseImageStore",
+	// profiles
+	"suseImageProfile",
+	"suseKiwiProfile",
+	"suseDockerfileProfile",
+	"rhnRegToken",
+	"rhnActivationKey",
+	// images
+	"rhnchecksum",
+	"suseImageInfo",
+	"suseImageOverview",
+	"suseImageInfoChannel",
+	"suseImageInfoPackage",
+	"suseimageinfoinstalledproduct",
+	"susecveimagechannel",
+	"suseImageCustomDataValue",
+	// packages in image - this is needed because of custom rpm with SSL certificate
+	"rhnpackageevr",
+	"rhnpackagearch",
+	"rhnpackagename",
+	// generic table for pillars
+	"suseSaltPillar",
+}
+
+var containersTableNames = []string{
+	// container specific use
+	"suseImageBuildHistory",
+	"suseImageRepoDigest",
+	// generic table for pillars
+	"suseSaltPillar",
+}
+
+func ImageTableNames() []string {
+	return imagesTableNames
+}
+
+func markAsExported(schema map[string]schemareader.Table, tables []string) {
+	for _, table := range tables {
+		tmp := schema[table]
+		tmp.Export = false
+		schema[table] = tmp
+	}
+}
+
+func dumpImageStores(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options ImageDumperOptions, store_label string) {
+
+	org_id := options.OrgID
+	var whereFilterClause = func(table schemareader.Table) string {
+		filter := fmt.Sprintf("WHERE store_type_id = (SELECT id FROM suseimagestoretype WHERE label = '%s')", store_label)
+		if org_id != 0 {
+			if _, ok := table.ColumnIndexes["org_id"]; ok {
+				filter = fmt.Sprintf(" AND org_id = %d", org_id)
+			}
+		}
+		return filter
+	}
+
+	processTables := make(map[string]bool)
+	log.Trace().Msg("Dumping all ImageStore tables")
+	writer.WriteString("-- OS Image Store\n")
+	processTables = dumper.DumpReachableTablesData(db, writer, schemaMetadata, []schemareader.Table{schemaMetadata["suseimagestore"]}, whereFilterClause,
+		[]string{}, processTables)
+	markAsExported(schemaMetadata, []string{"suseimagestore"})
+}
+
+func dumpOSImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options ImageDumperOptions) {
+
+	org_id := options.OrgID
+
+	// Image profiles
+	sqlForExistingProfiles := "SELECT profile_id FROM suseimageprofile WHERE image_type = 'kiwi'"
+	if org_id != 0 {
+		sqlForExistingProfiles = fmt.Sprintf("%s AND org_id = %d", sqlForExistingProfiles, org_id)
+	}
+	if options.StartingDate != "" {
+		sqlForExistingProfiles = fmt.Sprintf("%s AND modified > '%s'::timestamp", sqlForExistingProfiles, options.StartingDate)
+	}
+	profiles := sqlUtil.ExecuteQueryWithResults(db, sqlForExistingProfiles)
+	if len(profiles) > 0 {
+		log.Debug().Msg("Dumping ImageProfile tables")
+		writer.WriteString("-- OS Image Profiles\n")
+		for _, profile := range profiles {
+			log.Trace().Msgf("Exporting profile id %s", profile[0].Value)
+			whereClause := fmt.Sprintf("profile_id = '%s'", profile[0].Value)
+			tableProfilesData := dumper.DataCrawler(db, schemaMetadata, schemaMetadata["susekiwiprofile"], whereClause, options.StartingDate)
+
+			dumper.PrintTableDataOrdered(db, writer, schemaMetadata, schemaMetadata["susekiwiprofile"], tableProfilesData, dumper.PrintSqlOptions{})
+		}
+		markAsExported(schemaMetadata, []string{"suseimageprofile"})
+	} else {
+		log.Info().Msg("No Kiwi profiles found to export")
+	}
+
+	// Images
+	sqlForExistingImages := "SELECT id FROM suseimageinfo WHERE image_type = 'kiwi'"
+	if org_id != 0 {
+		sqlForExistingImages = fmt.Sprintf("%s AND org_id = %d", sqlForExistingImages, org_id)
+	}
+	if options.StartingDate != "" {
+		sqlForExistingImages = fmt.Sprintf("%s AND modified > '%s'::timestamp", sqlForExistingImages, options.StartingDate)
+	}
+	images := sqlUtil.ExecuteQueryWithResults(db, sqlForExistingImages)
+	if len(images) > 0 {
+		log.Debug().Msg("Dumping Image tables")
+		writer.WriteString("-- OS Images\n")
+		for _, image := range images {
+			log.Trace().Msgf("Exporting image id %s", image[0].Value)
+			whereClause := fmt.Sprintf("id = '%s'", image[0].Value)
+			tableImageData := dumper.DataCrawler(db, schemaMetadata, schemaMetadata["suseimageinfo"], whereClause, options.StartingDate)
+			dumper.PrintTableDataOrdered(db, writer, schemaMetadata, schemaMetadata["suseimageinfo"], tableImageData, dumper.PrintSqlOptions{})
+		}
+		markAsExported(schemaMetadata, []string{"suseimageinfo"})
+	}
+
+	// Dump image pillars from database if included. Pillar files dump is handled by pillarDumper
+	if _, ok := schemaMetadata["susesaltpillar"]; ok {
+		log.Debug().Msg("Dumping Image pillars")
+		writer.WriteString("-- OS Images pillars\n")
+		pillarFilter := "category = 'images'"
+		if org_id != 0 {
+			pillarFilter = fmt.Sprintf("%s AND org_id = %d", pillarFilter, org_id)
+		}
+		if options.StartingDate != "" {
+			pillarFilter = fmt.Sprintf("%s AND modified > '%s'::timestamp", pillarFilter, options.StartingDate)
+		}
+
+		pillarImageData := dumper.DataCrawler(db, schemaMetadata, schemaMetadata["susesaltpillar"], pillarFilter, options.StartingDate)
+		dumper.PrintTableDataOrdered(db, writer, schemaMetadata, schemaMetadata["susesaltpillar"], pillarImageData, dumper.PrintSqlOptions{})
+	}
+
+	log.Info().Msg("Kiwi image profiles export done")
+}
+
+// TODO, incomplete
+func dumpContainerImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options ImageDumperOptions) {
+	startingTables := []schemareader.Table{schemaMetadata["suseimagestore"], schemaMetadata["suseimageprofile"], schemaMetadata["suseimageinfo"]}
+
+	var whereFilterClause = func(table schemareader.Table) string {
+		filterOrg := ""
+		if _, ok := table.ColumnIndexes["org_id"]; ok {
+			filterOrg = " WHERE org_id IS NULL"
+		}
+		return filterOrg
+	}
+
+	dumper.DumpAllTablesData(db, writer, schemaMetadata, startingTables, whereFilterClause, []string{"susedockerfileprofile"})
+	log.Info().Msg("Dockerfile image profiles export done")
+	// no data to export as they are on remote registry
+}
+
+// Main entry point
+func DumpImageData(options ImageDumperOptions) {
+	log.Debug().Msg("Starting image metadata dump")
+	var outputFolderAbs = options.GetOutputFolderAbsPath()
+	var outputFolderImagesAbs = filepath.Join(outputFolderAbs, "images")
+	var outputFolderPillarAbs = filepath.Join(outputFolderAbs, "images", "pillars")
+	ValidateExistingFolder(outputFolderAbs)
+	ValidateExportFolder(outputFolderImagesAbs)
+	ValidateExportFolder(outputFolderPillarAbs)
+
+	// export DB data about images
+	db := schemareader.GetDBconnection(options.ServerConfig)
+	defer db.Close()
+	file, err := os.Create(filepath.Join(outputFolderAbs, "sql_statements_images.sql"))
+	if err != nil {
+		log.Fatal().Err(err).Msg("Error creating sql file")
+	}
+
+	defer file.Close()
+	bufferWriter := bufio.NewWriter(file)
+	defer bufferWriter.Flush()
+
+	log.Trace().Msg("Loading table schema")
+	schemaMetadata := schemareader.ReadTablesSchema(db, imagesTableNames)
+
+	bufferWriter.WriteString("BEGIN;\n")
+
+	if options.OSImage {
+		dumpImageStores(db, bufferWriter, schemaMetadata, options, "os_image")
+		dumpOSImageTables(db, bufferWriter, schemaMetadata, options)
+		pillarDumper.DumpImagePillars(outputFolderPillarAbs, options.OrgID, options.ServerConfig)
+		osImageDumper.DumpOsImages(outputFolderImagesAbs, options.OrgID)
+	}
+	if options.Containers {
+		dumpImageStores(db, bufferWriter, schemaMetadata, options, "registry")
+		dumpContainerImageTables(db, bufferWriter, schemaMetadata, options)
+	}
+
+	bufferWriter.WriteString("COMMIT;\n")
+}

--- a/entityDumper/imageDataDumper.go
+++ b/entityDumper/imageDataDumper.go
@@ -32,7 +32,6 @@ var imagesTableNames = []string{
 	"suseKiwiProfile",
 	"suseDockerfileProfile",
 	"rhnRegToken",
-	"rhnActivationKey",
 	// images
 	"rhnchecksum",
 	"suseImageInfo",

--- a/entityDumper/imageDataDumper.go
+++ b/entityDumper/imageDataDumper.go
@@ -71,7 +71,7 @@ func markAsExported(schema map[string]schemareader.Table, tables []string) {
 	}
 }
 
-func dumpImageStores(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options ImageDumperOptions, store_label string) {
+func dumpImageStores(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options DumperOptions, store_label string) {
 
 	org_id := options.OrgID
 	var whereFilterClause = func(table schemareader.Table) string {
@@ -92,7 +92,7 @@ func dumpImageStores(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string
 	markAsExported(schemaMetadata, []string{"suseimagestore"})
 }
 
-func dumpOSImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options ImageDumperOptions) {
+func dumpOSImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options DumperOptions) {
 
 	org_id := options.OrgID
 
@@ -161,7 +161,7 @@ func dumpOSImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[stri
 }
 
 // TODO, incomplete
-func dumpContainerImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options ImageDumperOptions) {
+func dumpContainerImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, options DumperOptions) {
 	startingTables := []schemareader.Table{schemaMetadata["suseimagestore"], schemaMetadata["suseimageprofile"], schemaMetadata["suseimageinfo"]}
 
 	var whereFilterClause = func(table schemareader.Table) string {
@@ -178,7 +178,7 @@ func dumpContainerImageTables(db *sql.DB, writer *bufio.Writer, schemaMetadata m
 }
 
 // Main entry point
-func DumpImageData(options ImageDumperOptions) {
+func dumpImageData(options DumperOptions) {
 	log.Debug().Msg("Starting image metadata dump")
 	var outputFolderAbs = options.GetOutputFolderAbsPath()
 	var outputFolderImagesAbs = filepath.Join(outputFolderAbs, "images")
@@ -204,7 +204,7 @@ func DumpImageData(options ImageDumperOptions) {
 
 	bufferWriter.WriteString("BEGIN;\n")
 
-	if options.OSImage {
+	if options.OSImages {
 		dumpImageStores(db, bufferWriter, schemaMetadata, options, "os_image")
 		dumpOSImageTables(db, bufferWriter, schemaMetadata, options)
 		pillarDumper.DumpImagePillars(outputFolderPillarAbs, options.OrgID, options.ServerConfig)

--- a/entityDumper/types.go
+++ b/entityDumper/types.go
@@ -15,7 +15,7 @@ type DumperOptions struct {
 	StartingDate              string
 	Containers                bool
 	OSImages                  bool
-	OrgID                     uint
+	Orgs                      []uint
 }
 
 func (opt *DumperOptions) GetOutputFolderAbsPath() string {

--- a/entityDumper/types.go
+++ b/entityDumper/types.go
@@ -22,6 +22,19 @@ func (opt *DumperOptions) GetOutputFolderAbsPath() string {
 	return opt.outputFolderAbsPath
 }
 
+type ImageDumperOptions struct {
+	ServerConfig string
+	OutputFolder string
+	OSImage      bool
+	Containers   bool
+	OrgID        uint
+	StartingDate string
+}
+
+func (opt *ImageDumperOptions) GetOutputFolderAbsPath() string {
+	return utils.GetAbsPath(opt.OutputFolder)
+}
+
 type channelsProcess struct {
 	channelsMap map[string]bool
 	channels    []string

--- a/entityDumper/types.go
+++ b/entityDumper/types.go
@@ -13,6 +13,9 @@ type DumperOptions struct {
 	outputFolderAbsPath       string
 	MetadataOnly              bool
 	StartingDate              string
+	Containers                bool
+	OSImages                  bool
+	OrgID                     uint
 }
 
 func (opt *DumperOptions) GetOutputFolderAbsPath() string {
@@ -20,19 +23,6 @@ func (opt *DumperOptions) GetOutputFolderAbsPath() string {
 		opt.outputFolderAbsPath = utils.GetAbsPath(opt.OutputFolder)
 	}
 	return opt.outputFolderAbsPath
-}
-
-type ImageDumperOptions struct {
-	ServerConfig string
-	OutputFolder string
-	OSImage      bool
-	Containers   bool
-	OrgID        uint
-	StartingDate string
-}
-
-func (opt *ImageDumperOptions) GetOutputFolderAbsPath() string {
-	return utils.GetAbsPath(opt.OutputFolder)
 }
 
 type channelsProcess struct {

--- a/entityDumper/utils.go
+++ b/entityDumper/utils.go
@@ -1,0 +1,34 @@
+package entityDumper
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/rs/zerolog/log"
+	"github.com/uyuni-project/inter-server-sync/utils"
+)
+
+func ValidateExportFolder(outputFolderAbs string) {
+	ValidateExistingFolder(outputFolderAbs)
+	outputFolder, _ := os.Open(outputFolderAbs)
+	defer outputFolder.Close()
+	_, errEmpty := outputFolder.Readdirnames(1) // Or f.Readdir(1)
+	if errEmpty != io.EOF {
+		log.Fatal().Msg(fmt.Sprintf("Export location is not empty: %s", outputFolderAbs))
+	}
+}
+
+func ValidateExistingFolder(outputFolderAbs string) {
+	err := utils.FolderExists(outputFolderAbs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err := os.MkdirAll(outputFolderAbs, 0755)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Error creating directory")
+			}
+		} else {
+			log.Fatal().Err(err).Msg("Error getting output folder")
+		}
+	}
+}

--- a/schemareader/reader_test.go
+++ b/schemareader/reader_test.go
@@ -1,10 +1,11 @@
 package schemareader
 
 import (
-	"github.com/DATA-DOG/go-sqlmock"
-	"github.com/uyuni-project/inter-server-sync/tests"
 	"reflect"
 	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/uyuni-project/inter-server-sync/tests"
 )
 
 const (
@@ -26,7 +27,7 @@ func TestProcessTable(t *testing.T) {
 	UniqueIndexMostColumnsCase(repo)
 
 	// Act
-	table := processTable(repo.DB, TableName, true)
+	table, _ := processTable(repo.DB, TableName, true)
 
 	// Assert
 	indexesEqual := reflect.DeepEqual(table.MainUniqueIndexName, UniqueIndexName03)

--- a/schemareader/reader_test.go
+++ b/schemareader/reader_test.go
@@ -38,9 +38,9 @@ func TestProcessTable(t *testing.T) {
 
 func UniqueIndexMostColumnsCase(repo *tests.DataRepository) {
 
-	repo.ExpectWithRecords(ReadColumnNames, sqlmock.NewRows([]string{"column_name"}), TableName)
-	repo.ExpectWithRecords(ReadPkColumnNames, sqlmock.NewRows([]string{"attname"}), TableName)
-	repo.ExpectWithRecords(ReadPkSequence, sqlmock.NewRows([]string{"sequence_name"}), TableName)
+	repo.ExpectWithRecords(ReadColumnNames, sqlmock.NewRows([]string{"column_name"}).AddRow(""), TableName)
+	repo.ExpectWithRecords(ReadPkColumnNames, sqlmock.NewRows([]string{"attname"}).AddRow(""), TableName)
+	repo.ExpectWithRecords(ReadPkSequence, sqlmock.NewRows([]string{"sequence_name"}).AddRow(""), TableName)
 
 	// Read indexes information to get three indexes
 	repo.ExpectWithRecords(

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -104,9 +104,6 @@ func applyTableFilters(table Table) Table {
 		virtualIndexColumns := []string{"profile_id"}
 		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
 		table.MainUniqueIndexName = VirtualIndexName
-	case "rhnactivationkey":
-		// Activation keys are to be managed by salt states or XMLRPC API
-		table.Export = false
 	}
 
 	return table


### PR DESCRIPTION
Implementation of: https://github.com/SUSE/spacewalk/issues/15046

This PR adds options to export and import OS images.

Export by default exports both channels and images (tables, pillars and images), but this PR also adds an option to export only images.
Export can also be limited by organization id.

Import autodetect what everything is present in export folder and selectively import channels or images or both.