### PR TITLE
correct on conflict clause for rhnPackageCapability

### DIFF
--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -347,18 +347,6 @@ func formatOnConflict(row []sqlUtil.RowDataStructure, table schemareader.Table) 
 		} else {
 			return "(version, release, epoch, ((evr).type)) WHERE epoch IS NOT NULL DO NOTHING"
 		}
-	case "rhnpackagecapability":
-		var version interface{} = nil
-		for _, field := range row {
-			if strings.Compare(field.ColumnName, "version") == 0 {
-				version = field.Value
-			}
-		}
-		if version == nil {
-			return "(name) WHERE version IS NULL DO NOTHING"
-		} else {
-			return "(name, version) WHERE version IS NOT NULL DO NOTHING"
-		}
 	}
 	columnAssignment := formatColumnAssignment(table)
 	return fmt.Sprintf("%s DO UPDATE SET %s", constraint, columnAssignment)

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -47,6 +47,11 @@ func applyTableFilters(table Table) Table {
 	case "rhnpackagecapability":
 		// pkid: rhn_pkg_capability_id_pk
 		table.PKSequence = "RHN_PKG_CAPABILITY_ID_SEQ"
+		// table has real unique index, but they are complex and useless, since we do nothing in the conflict
+		// to simplify the code we can create a virtual index that will insure all data exists as supposed
+		virtualIndexColumns := []string{"name", "version"}
+		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
+		table.MainUniqueIndexName = VirtualIndexName
 	}
 	return table
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

After some changes in the table rhnPackageCapability, the inter server sync code needed to be adapted to cope with them.

Changes in the table definition: https://github.com/uyuni-project/uyuni/pull/4073/files#diff-e490c86128112eb64ffbefce85d10f854a6cc2ea019a88072d226ccf85387482

Fixes: https://github.com/SUSE/spacewalk/issues/16597

With this solution, we cope we all server versions. 
Since we are doing "ignore" in the on conflict clause, we can just skip the insert in case the record already exists.
To be able to have this behavior, we can create a virtual index on the conflicting columns, and use the same colunms.

It will check if the version is null, and behave acording. 