### PR TITLE
export rhnpackagekey table on software channels

### DIFF
--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -55,6 +55,7 @@ func SoftwareChannelTableNames() []string {
 		"rhnerratafilepackage",       // clean
 		"rhnerratafilepackagesource", // clean
 		"rhnpackagekeyassociation",
+		"rhnpackagekey",
 		"rhnerratabuglist", // clean
 		"rhncve",
 		"rhnerratacve",     // clean


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>
Bug fix for: https://github.com/SUSE/spacewalk/issues/16709

The table `rhnpackagekey` was not being exported with software channels.