### PR TITLE
software channels partial export based on date

### DIFF
--- a/dumper/crawler_test.go
+++ b/dumper/crawler_test.go
@@ -52,6 +52,7 @@ func TestShouldCreateDataDumper(t *testing.T) {
 		testCase.schemaMetadata,
 		testCase.startTable,
 		testCase.startQueryFilter,
+		"2022-01-01",
 	)
 
 	// Assert

--- a/entityDumper/types.go
+++ b/entityDumper/types.go
@@ -5,12 +5,13 @@ import (
 )
 
 type ChannelDumperOptions struct {
-	ServerConfig string
-	ChannelLabels []string
+	ServerConfig              string
+	ChannelLabels             []string
 	ChannelWithChildrenLabels []string
-	OutputFolder string
-	outputFolderAbsPath string
-	MetadataOnly bool
+	OutputFolder              string
+	outputFolderAbsPath       string
+	MetadataOnly              bool
+	StartingDate              string
 }
 
 func (opt *ChannelDumperOptions) GetOutputFolderAbsPath() string {
@@ -21,11 +22,11 @@ func (opt *ChannelDumperOptions) GetOutputFolderAbsPath() string {
 }
 
 type channelsProcess struct {
-	channelsMap map[string] bool
+	channelsMap map[string]bool
 	channels    []string
 }
 
-func (c *channelsProcess) addChannelLabel(label string)  {
+func (c *channelsProcess) addChannelLabel(label string) {
 	c.channelsMap[label] = true
 	c.channels = append(c.channels, label)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,11 +3,13 @@ package utils
 import (
 	"bufio"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 //ReverseArray reverses the array
@@ -45,7 +47,7 @@ func GetAbsPath(path string) string {
 	return result
 }
 
-func FolderExists(path string) error{
+func FolderExists(path string) error {
 	folder, err := os.Open(path)
 	defer folder.Close()
 	if err != nil {
@@ -69,8 +71,8 @@ func GetCurrentServerVersion() (string, string) {
 	files := []string{rhndefault, webpath, altpath}
 	property := []string{"product_name", "web.product_name"}
 	product := "SUSE Manager"
-	p, err := getProperty(files,property)
-	if err == nil{
+	p, err := getProperty(files, property)
+	if err == nil {
 		product = p
 	}
 
@@ -86,8 +88,8 @@ func GetCurrentServerVersion() (string, string) {
 	return version, product
 }
 
-func getProperty(filePaths []string, names[]string) (string, error) {
-	for _, path:= range filePaths {
+func getProperty(filePaths []string, names []string) (string, error) {
+	for _, path := range filePaths {
 		for _, search := range names {
 			p, err := ScannerFunc(path, search)
 			if err == nil {
@@ -111,7 +113,7 @@ func ScannerFunc(path string, search string) (string, error) {
 			splits := strings.Split(scanner.Text(), "=")
 			output = splits[1]
 			if output == " SUSE Manager" {
-				output = strings.Replace(output, " SUSE Manager", "SUSE Manager", 1 )
+				output = strings.Replace(output, " SUSE Manager", "SUSE Manager", 1)
 			} else {
 				splits = strings.Split(output, " ")
 				output = splits[len(splits)-1]
@@ -120,4 +122,18 @@ func ScannerFunc(path string, search string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("String not found!")
+}
+
+func ValidateDate(date string) (string, bool) {
+	if date == "" {
+		return "", true
+	}
+
+	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02"} {
+		t, err := time.Parse(layout, date)
+		if err == nil {
+			return t.Format(layout), true
+		}
+	}
+	return "", false
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -5,13 +5,35 @@ import (
 )
 
 func TestArrayRevert(t *testing.T) {
-	myArray := []int{1,2,3}
+	myArray := []int{1, 2, 3}
 	myArrayRevert := make([]int, len(myArray))
 	copy(myArrayRevert, myArray)
 	ReverseArray(myArrayRevert)
 	for i, value := range myArray {
-		if myArrayRevert[len(myArray) - i - 1] != value {
-			t.Fatalf("values are different: %d -> %d",  myArrayRevert[len(myArray) - i - 1],value) // to indicate test failed
+		if myArrayRevert[len(myArray)-i-1] != value {
+			t.Fatalf("values are different: %d -> %d", myArrayRevert[len(myArray)-i-1], value) // to indicate test failed
 		}
+	}
+}
+
+func TestValidateDateValid(t *testing.T) {
+	date := "2022-01-01"
+	validatedDate, ok := ValidateDate(date)
+	if !ok {
+		t.Errorf("The date is not validated properly.")
+	}
+	if date != validatedDate {
+		t.Errorf("The date is not validated properly.")
+	}
+}
+
+func TestValidateDateInvalid(t *testing.T) {
+	date := ""
+	validatedDate, ok := ValidateDate(date)
+	if !ok {
+		t.Errorf("The date should be valid.")
+	}
+	if validatedDate != "" {
+		t.Errorf("The date is not validated properly.")
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>
Fixes: https://github.com/SUSE/spacewalk/issues/16768

This PR allows to partially export software channels base on a starting date.
It will reduce the amount of data to be synchronized. The first synchronization should be full, which will take the same time as before, however, updates should be faster.