### PR TITLE
Improve memory usage on software channels export

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -99,7 +99,12 @@ func runPackageFileSync(absImportDir string) {
 		}
 	}
 
-	cmd := exec.Command("rsync", "-og", "--chown=wwwrun:www", "-r",
+	debugFlag := ""
+	if log.Debug().Enabled() {
+		debugFlag = "-v"
+	}
+
+	cmd := exec.Command("rsync", debugFlag, "-og", "--chown=wwwrun:www", "-r",
 		packagesImportDir, "/var/spacewalk/packages/")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -127,7 +132,12 @@ func runImageFileSync(absImportDir string, serverFQDN string) {
 		}
 	}
 
-	cmd := exec.Command("rsync", "-og", "--chown=salt:susemanager", "--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r",
+	debugFlag := ""
+	if log.Debug().Enabled() {
+		debugFlag = "-v"
+	}
+
+	cmd := exec.Command("rsync", debugFlag, "-og", "--chown=salt:susemanager", "--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r",
 		"-r", "--exclude=pillars", imagesImportDir+"/", "/srv/www/os-images")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:     "inter-server-sync",
 	Short:   "Uyuni Inter Server Sync tool",
-	Version: "0.2.3",
+	Version: "0.2.4",
 }
 
 func Execute() {

--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -27,6 +27,9 @@ func DataCrawler(db *sql.DB, schemaMetadata map[string]schemareader.Table, start
 			count := 0
 			for {
 				time.Sleep(30 * time.Second)
+				if len(itemsToProcess) == 0 {
+					break
+				}
 				keysSize := 0
 				maxSize := 0
 				table := ""
@@ -39,10 +42,6 @@ func DataCrawler(db *sql.DB, schemaMetadata map[string]schemareader.Table, start
 				}
 				log.Debug().Msgf("#count: %d #rowsToProcess: #%d ;  #rowsToExport: #%d  --> Bigger export table: %s: #%d",
 					count, len(itemsToProcess), keysSize, table, maxSize)
-
-				if len(itemsToProcess) == 0 {
-					break
-				}
 				count++
 			}
 		}()
@@ -186,7 +185,7 @@ func shouldFollowToLinkPreOrder(path []string, currentTable schemareader.Table, 
 			}
 		}
 	}
-	
+
 	return true
 }
 

--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -40,7 +40,7 @@ func DataCrawler(db *sql.DB, schemaMetadata map[string]schemareader.Table, start
 						table = key
 					}
 				}
-				log.Debug().Msgf("#count: %d #rowsToProcess: #%d ;  #rowsToExport: #%d  --> Bigger export table: %s: #%d",
+				log.Debug().Msgf("#count: %d #rowsToProcess: #%d ;  #rowsToDiscover: #%d  --> Bigger export table: %s: #%d",
 					count, len(itemsToProcess), keysSize, table, maxSize)
 				count++
 			}

--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -4,6 +4,9 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
 
 	"github.com/uyuni-project/inter-server-sync/schemareader"
 	"github.com/uyuni-project/inter-server-sync/sqlUtil"
@@ -12,11 +15,38 @@ import (
 // DataCrawler will go through all the elements in the initialDataSet an extract related data
 // for all tables presented in the schemaMetadata by following foreign keys and references to the table row
 // The result will be a structure containing ID of each row which should be exported per table
-func DataCrawler(db *sql.DB, schemaMetadata map[string]schemareader.Table, startTable schemareader.Table, startQueryFilter string, startingDate string) DataDumper {
+func DataCrawler(db *sql.DB, schemaMetadata map[string]schemareader.Table, startTable schemareader.Table,
+	startQueryFilter string, startingDate string) DataDumper {
 
 	result := DataDumper{make(map[string]TableDump, 0), make(map[string]bool)}
 
 	itemsToProcess := initialDataSet(db, startTable, startQueryFilter)
+
+	if log.Debug().Enabled() {
+		go func() {
+			count := 0
+			for {
+				time.Sleep(30 * time.Second)
+				keysSize := 0
+				maxSize := 0
+				table := ""
+				for key, value := range result.TableData {
+					keysSize = keysSize + len(value.KeyMap)
+					if len(value.KeyMap) > maxSize {
+						maxSize = len(value.KeyMap)
+						table = key
+					}
+				}
+				log.Debug().Msgf("#count: %d #rowsToProcess: #%d ;  #rowsToExport: #%d  --> Bigger export table: %s: #%d",
+					count, len(itemsToProcess), keysSize, table, maxSize)
+
+				if len(itemsToProcess) == 0 {
+					break
+				}
+				count++
+			}
+		}()
+	}
 
 IterateItemsLoop:
 	for len(itemsToProcess) > 0 {
@@ -43,7 +73,7 @@ IterateItemsLoop:
 			resultTableValues = TableDump{TableName: table.Name, KeyMap: make(map[string]bool), Keys: make([]TableKey, 0)}
 		}
 		resultTableValues.KeyMap[keyIdToMap] = true
-		resultTableValues.Keys = append(resultTableValues.Keys, TableKey{keyColumnData})
+		resultTableValues.Keys = append(resultTableValues.Keys, keyColumnData)
 
 		result.TableData[table.Name] = resultTableValues
 		_, okPath := result.Paths[strings.Join(itemToProcess.path, ",")]
@@ -73,27 +103,27 @@ func initialDataSet(db *sql.DB, startTable schemareader.Table, whereFilter strin
 	return initialDataSet
 }
 
-func generateKeyIdToMap(data map[string]string) string {
+func generateKeyIdToMap(data TableKey) string {
 	keyValuesList := make([]string, 0)
-	for _, value := range data {
-		valueStr := fmt.Sprintf("%s", value)
+	for _, value := range data.Key {
+		valueStr := fmt.Sprintf("%s", value.Value)
 		keyValuesList = append(keyValuesList, valueStr)
 	}
 	return strings.Join(keyValuesList, "$$")
 }
 
-func extractRowKeyData(table schemareader.Table, itemToProcess processItem) map[string]string {
-	keyColumnData := make(map[string]string)
+func extractRowKeyData(table schemareader.Table, itemToProcess processItem) TableKey {
+	keys := make([]RowKey, 0)
 	if len(table.PKColumns) > 0 {
 		for pkColumn, _ := range table.PKColumns {
-			keyColumnData[pkColumn] = formatField(itemToProcess.row[table.ColumnIndexes[pkColumn]])
+			keys = append(keys, RowKey{pkColumn, formatField(itemToProcess.row[table.ColumnIndexes[pkColumn]])})
 		}
 	} else {
 		for _, pkColumn := range table.UniqueIndexes[table.MainUniqueIndexName].Columns {
-			keyColumnData[pkColumn] = formatField(itemToProcess.row[table.ColumnIndexes[pkColumn]])
+			keys = append(keys, RowKey{pkColumn, formatField(itemToProcess.row[table.ColumnIndexes[pkColumn]])})
 		}
 	}
-	return keyColumnData
+	return TableKey{keys}
 }
 
 func followReferencesFrom(db *sql.DB, schemaMetadata map[string]schemareader.Table, table schemareader.Table, row processItem, startingDate string) []processItem {

--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -89,11 +89,11 @@ func exportTablesData(db *sql.DB, writer *bufio.Writer, schemaMetadata map[strin
 			count := 0
 			for {
 				time.Sleep(30 * time.Second)
-				log.Debug().Msgf("#count: %d #cacheSize %d -- #writtenRows: #%d of %d",
-					count, len(cache), totalExportedRecords, totalRecords)
 				if !processing {
 					break
 				}
+				log.Debug().Msgf("#count: %d #cacheSize %d -- #writtenRows: #%d of %d",
+					count, len(cache), totalExportedRecords, totalRecords)
 				count++
 			}
 		}()

--- a/dumper/packageDumper/packageDumper.go
+++ b/dumper/packageDumper/packageDumper.go
@@ -33,7 +33,7 @@ func DumpPackageFiles(db *sql.DB, schemaMetadata map[string]schemareader.Table, 
 				}
 				time.Sleep(30 * time.Second)
 				log.Debug().Msgf("#count: %d -- #exportedPackageFiles: #%d of %d",
-					count, totalPackages, exportedpackages)
+					count, exportedpackages, totalPackages)
 				count++
 			}
 		}()
@@ -48,7 +48,6 @@ func DumpPackageFiles(db *sql.DB, schemaMetadata map[string]schemareader.Table, 
 			upperLimit = len(packageKeysData.Keys)
 		}
 		rows := dumper.GetRowsFromKeys(db, table, packageKeysData.Keys[exportPoint:upperLimit])
-		exportedpackages += len(rows)
 		for _, rowPackage := range rows {
 			path := rowPackage[pathIndex]
 			source := fmt.Sprintf("%s/%s", serverDataFolder, path.Value)
@@ -57,6 +56,7 @@ func DumpPackageFiles(db *sql.DB, schemaMetadata map[string]schemareader.Table, 
 			if error != nil {
 				log.Panic().Err(error).Msg("could not Copy File")
 			}
+			exportedpackages++
 		}
 		exportPoint = upperLimit
 	}

--- a/dumper/packageDumper/packageDumper.go
+++ b/dumper/packageDumper/packageDumper.go
@@ -3,7 +3,8 @@ package packageDumper
 import (
 	"database/sql"
 	"fmt"
-	"log"
+	"github.com/rs/zerolog/log"
+	"time"
 
 	"github.com/uyuni-project/inter-server-sync/dumper"
 	"github.com/uyuni-project/inter-server-sync/schemareader"
@@ -17,23 +18,47 @@ func DumpPackageFiles(db *sql.DB, schemaMetadata map[string]schemareader.Table, 
 	table := schemaMetadata[packageKeysData.TableName]
 	pathIndex := table.ColumnIndexes["path"]
 
+	totalPackages := len(packageKeysData.Keys)
+	log.Debug().Msgf("Total package files to copy: %d", totalPackages)
+
+	exportedpackages := 0
+	processing := true
+
+	if log.Debug().Enabled() {
+		go func() {
+			count := 0
+			for {
+				if !processing {
+					break
+				}
+				time.Sleep(30 * time.Second)
+				log.Debug().Msgf("#count: %d -- #exportedPackageFiles: #%d of %d",
+					count, totalPackages, exportedpackages)
+				count++
+			}
+		}()
+	}
+
 	exportPoint := 0
 	batchSize := 500
+
 	for len(packageKeysData.Keys) > exportPoint {
 		upperLimit := exportPoint + batchSize
 		if upperLimit > len(packageKeysData.Keys) {
 			upperLimit = len(packageKeysData.Keys)
 		}
 		rows := dumper.GetRowsFromKeys(db, table, packageKeysData.Keys[exportPoint:upperLimit])
+		exportedpackages += len(rows)
 		for _, rowPackage := range rows {
 			path := rowPackage[pathIndex]
 			source := fmt.Sprintf("%s/%s", serverDataFolder, path.Value)
 			target := fmt.Sprintf("%s/%s", outputFolder, path.Value)
 			_, error := dumper.Copy(source, target)
 			if error != nil {
-				log.Panic("could not Copy File: ", error)
+				log.Panic().Err(error).Msg("could not Copy File")
 			}
 		}
 		exportPoint = upperLimit
 	}
+	processing = false
 }

--- a/dumper/types.go
+++ b/dumper/types.go
@@ -7,8 +7,13 @@ import (
 	"github.com/uyuni-project/inter-server-sync/sqlUtil"
 )
 
+type RowKey struct {
+	Column string
+	Value  string
+}
+
 type TableKey struct {
-	Key map[string]string
+	Key []RowKey
 }
 
 type TableDump struct {

--- a/dumper/utils_test.go
+++ b/dumper/utils_test.go
@@ -4,9 +4,10 @@ import (
 	"bufio"
 	"database/sql"
 	"fmt"
-	"github.com/uyuni-project/inter-server-sync/schemareader"
 	"reflect"
 	"strings"
+
+	"github.com/uyuni-project/inter-server-sync/schemareader"
 )
 
 type TablesGraph map[string][]string
@@ -60,17 +61,19 @@ func createMetaDataGraph(graph TablesGraph) (MetaDataGraph, DataDumper) {
 				schemareader.Reference{TableName: parent, ColumnMapping: map[string]string{"fk_id": "id"}},
 			)
 			schemaMetadata[child] = childTable
+			k := []RowKey{{"id", fmt.Sprintf("'%04d'", 1)}}
 			dataDumper.TableData[child] = TableDump{
 				TableName: child,
 				KeyMap:    map[string]bool{fmt.Sprintf("'%04d'", 1): true},
-				Keys:      []TableKey{{Key: map[string]string{"id": fmt.Sprintf("'%04d'", 1)}}},
+				Keys:      []TableKey{{Key: k}},
 			}
 		}
 		schemaMetadata[parent] = parentTable
+		k := []RowKey{{"id", fmt.Sprintf("'%04d'", 1)}}
 		dataDumper.TableData[parent] = TableDump{
 			TableName: parent,
 			KeyMap:    map[string]bool{fmt.Sprintf("'%04d'", 1): true},
-			Keys:      []TableKey{{Key: map[string]string{"id": fmt.Sprintf("'%04d'", 1)}}},
+			Keys:      []TableKey{{Key: k}},
 		}
 	}
 	return schemaMetadata, dataDumper
@@ -117,7 +120,8 @@ func allPathsPostOrder(graph TablesGraph, root string) map[string]bool {
 func setNumberOfRecordsForTable(tc *writerTestCase, tableName string, num int) {
 	var keys []TableKey
 	for i := 0; i < num; i++ {
-		keys = append(keys, TableKey{Key: map[string]string{"id": fmt.Sprintf("%04d", i+1)}})
+		k := []RowKey{{"id", fmt.Sprintf("%04d", i+1)}}
+		keys = append(keys, TableKey{Key: k})
 	}
 	tableData := tc.dumper.TableData[tableName]
 	tableData.Keys = keys

--- a/dumper/writer_test.go
+++ b/dumper/writer_test.go
@@ -277,7 +277,7 @@ func TestPrintTableData(t *testing.T) {
 
 	// 02 Act
 	orderedTables := getTablesExportOrder(testCase.schemaMetadata, testCase.startingTable, testCase.processedTables, testCase.path)
-	exportTableData(
+	exportTablesData(
 		testCase.repo.DB,
 		testCase.repo.Writer,
 		testCase.schemaMetadata,

--- a/dumper/writer_test.go
+++ b/dumper/writer_test.go
@@ -276,14 +276,13 @@ func TestPrintTableData(t *testing.T) {
 	testCase.repo.Expect("SELECT id, fk_id FROM v22 WHERE id = $1;", 1)
 
 	// 02 Act
-	printTableData(
+	orderedTables := getTablesExportOrder(testCase.schemaMetadata, testCase.startingTable, testCase.processedTables, testCase.path)
+	exportTableData(
 		testCase.repo.DB,
 		testCase.repo.Writer,
 		testCase.schemaMetadata,
+		orderedTables,
 		testCase.dumper,
-		testCase.startingTable,
-		testCase.processedTables,
-		testCase.path,
 		testCase.options,
 	)
 

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -204,12 +204,13 @@ func processChannel(db *sql.DB, writer *bufio.Writer, channelLabel string,
 	whereFilter := fmt.Sprintf("label = '%s'", channelLabel)
 	tableData := dumper.DataCrawler(db, schemaMetadata, schemaMetadata["rhnchannel"], whereFilter, options.StartingDate)
 
-	totalRows := 0
-	for _, value := range tableData.TableData {
-		totalRows = totalRows + len(value.KeyMap)
+	if log.Debug().Enabled() {
+		totalRows := 0
+		for _, value := range tableData.TableData {
+			totalRows = totalRows + len(value.KeyMap)
+		}
+		log.Debug().Msgf("finished table data crawler. Total database rows to export: %d", totalRows)
 	}
-
-	log.Debug().Msgf("finished table data crawler. Total database rows to export: %d", totalRows)
 
 	cleanWhereClause := fmt.Sprintf(`WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = '%s')`, channelLabel)
 	printOptions := dumper.PrintSqlOptions{

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -203,7 +203,13 @@ func processChannel(db *sql.DB, writer *bufio.Writer, channelLabel string,
 	schemaMetadata map[string]schemareader.Table, options DumperOptions) {
 	whereFilter := fmt.Sprintf("label = '%s'", channelLabel)
 	tableData := dumper.DataCrawler(db, schemaMetadata, schemaMetadata["rhnchannel"], whereFilter, options.StartingDate)
-	log.Debug().Msg("finished table data crawler")
+
+	totalRows := 0
+	for _, value := range tableData.TableData {
+		totalRows = totalRows + len(value.KeyMap)
+	}
+
+	log.Debug().Msgf("finished table data crawler. Total database rows to export: %d", totalRows)
 
 	cleanWhereClause := fmt.Sprintf(`WHERE rhnchannel.id = (SELECT id FROM rhnchannel WHERE label = '%s')`, channelLabel)
 	printOptions := dumper.PrintSqlOptions{

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -167,6 +167,8 @@ func processAndInsertProducts(db *sql.DB, writer *bufio.Writer) {
 	}
 
 	dumper.DumpAllTablesData(db, writer, schemaMetadata, startingTables, whereFilterClause, onlyIfParentExistsTables)
+	writer.WriteString("-- end of product tables")
+	writer.WriteString("\n")
 	log.Debug().Msg("products export done")
 }
 

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,3 +1,6 @@
+* Improve memory usage and log information #17193
+
+
 -------------------------------------------------------------------
 Thu 21 Jul 11:21:25 UTC 2022 - Artem Shiliaev <artem.shiliaev@suse.com>
 


### PR DESCRIPTION
Followup of: https://github.com/SUSE/spacewalk/issues/16963
Implementation of: https://github.com/SUSE/spacewalk/issues/17193
Improve memory usage in datacrawler.

This can be done by reducing the type of structure used in [1] which is responsible for 80%+ of the memory usage.

![image](https://user-images.githubusercontent.com/2996004/153856820-f77900ad-901a-42e9-98fd-5e43713a60ad.png)


## Results
- Channel label: sle-module-basesystem15-updates-x86_64-sled
- Time in DataCrawler: 
  - Base case: ~10min(+-30sec), from 14:34:52 to 14:44:52
  - Improved case: ~10min(+-30sec), from 14:54:44 to 15:04:44
- Peak memory usage:
  - Base case ~1433mb
  - Improved case ~543mb

Before:
![image](https://user-images.githubusercontent.com/2996004/155134808-9e9e5b72-2d70-4012-b970-aeee35954807.png)

After:
![image](https://user-images.githubusercontent.com/2996004/155134831-ad46628c-19c9-43ee-b3e6-d6d769642d09.png)


[1] https://github.com/uyuni-project/inter-server-sync/blob/main/dumper/types.go#L9-L13

Signed-off-by: Ricardo Mateus <rmateus@suse.com>