### PR TITLE
clean lookup cache after processing a channel

### DIFF
--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -21,6 +21,7 @@ func PrintTableDataOrdered(db *sql.DB, writer *bufio.Writer, schemaMetadata map[
 
 	printCleanTables(db, writer, schemaMetadata, startingTable, make(map[string]bool), make([]string, 0), options)
 	printTableData(db, writer, schemaMetadata, data, startingTable, make(map[string]bool), make([]string, 0), options)
+	cache = make(map[string]string)
 }
 
 /**


### PR DESCRIPTION
During data writing, we keep a cache to avoid calls to database to collect lookups for foreign keys.
With this change, we clean this cache after a channel is processed since we don't expect channels to share that much data.

Fix for: https://github.com/SUSE/spacewalk/issues/16963

Signed-off-by: Ricardo Mateus <rmateus@suse.com>