### PR TITLE
add changes file and spec in preparation to change build process

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 [![Test](https://github.com/uyuni-project/inter-server-sync/actions/workflows/github-actions-tests.yml/badge.svg)](https://github.com/uyuni-project/inter-server-sync/actions/workflows/github-actions-tests.yml)
 
-## Installation
-Use the repository: https://download.opensuse.org/repositories/home:/RDiasMateus:/iss/
-
 ## Usage
 run the command for more information:
 `inter-server-sync -h`
@@ -39,14 +36,43 @@ Steps to run in locally in development mode:
 
 `go run . dot --serverConfig=rhn.conf |  dot -Tx11`
 
-### Profile
-Run with profile: `go run . -cpuprofile=cpu.prof -memprofile=mem.prof ...`
+## Build and release
 
-View Profile data: `go tool pprof -web mem.prof`
+### 1. Update cmd version
 
-## Packaging
+- Edit file `cmd/root.go` "Version" property to the desire version
+- On project root folder run `osc vc` to update the changes file with the release data
+- Manually update changes file with the release number for the next release
+- commit and push to github
 
-OBS project: https://build.opensuse.org/project/show/home:RDiasMateus:iss
+### 2. Create tag
 
-## Service to create vendor sources
-`osc service rundisabled`
+- Create a tag with the version number using the format "v0.0.0" and push it to github
+
+### 3. Create a github release (optional)
+
+- On github create a new version release based on the previous tag
+
+### 4. OBS: project preparetion
+
+- Projects names:
+    - Uyuni: `systemsmanagement:Uyuni:Master`
+    - Head: Devel: `Galaxy:Manager:Head`
+    - Manager 4.2: `Devel:Galaxy:Manager:4.2`
+- Pakcage name: `inter-server-sync`
+
+On porject working directory: 
+
+1. Adapt the `_services` file to be able to download the correct tag for the version
+2. Run all services: `osc service runall`
+3. Check the the changes files is correctly updated
+4. Check spec file was correctly updated with the release version
+5. Add all files: `osc ar`
+6. Remove old version files `tar` and `osinfo` (`osc rm filename`)
+7. Commit everything with `osc commit`
+
+### 5. OBS: create submit requests
+
+Uyuni: `osc sr --no-cleanup <your_project> inter-server-sync systemsmanagement:Uyuni:Master`
+Manager Head: `iosc sr --no-cleanup openSUSE.org:<your_project> inter-server-sync Devel:Galaxy:Manager:Head`
+For each maintained SUSE Manager version, one SR in the form: `iosc sr --no-cleanup openSUSE.org:<your_project> inter-server-sync Devel:Galaxy:Manager:X.Y`

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,0 +1,52 @@
+- version x.x.x
+  * Allow export and import of configuration channels
+  * Clean lookup cache after processing a channel (bsc#1195750)
+  * Improve lookup method for generate foreign key export
+
+-------------------------------------------------------------------
+Sun Feb 14 11:36:09 UTC 2022 - Stefan Bluhm <stefan.bluhm@clacee.eu>
+
+- Adapted for build on Enterprise Linux 8.
+
+-------------------------------------------------------------------
+Mon Jan 31 14:00:15 UTC 2022 - Ricardo Mateus <rmateus@suse.com>
+
+- version 0.0.7
+  * Correct database sequence name used for table rhnChecksum
+  * Add support for partial exports based on a date (bsc#1195008)
+  * Export table rhnpackagekey (bsc#1194764)
+
+-------------------------------------------------------------------
+Tue Dec 21 15:38:27 UTC 2021 - Ricardo Mateus <rmateus@suse.com>
+
+- version 0.0.6
+  * Fix bug when exporting rhnpackagecapability table
+
+-------------------------------------------------------------------
+Tue Sep  7 16:24:21 UTC 2021 - Ricardo Mateus <rmateus@suse.com>
+
+- Use systemd rpm macro instead of direct call to systemctl
+
+-------------------------------------------------------------------
+Thu Sep  2 10:20:21 UTC 2021 - Jordi Massaguer <jmassaguerpla@suse.com>
+
+- fix post section: use try-restart instead of restart, so we do not
+  start rsyslog if it was not running before.
+
+-------------------------------------------------------------------
+Wed Jul 28 14:56:36 UTC 2021 - Ricardo Mateus <rmateus@suse.com>
+
+- version 0.0.5
+- correctly export packages change log data
+
+-------------------------------------------------------------------
+Tue Jul 23 17:24:50 UTC 2021 - Ricardo Mateus <rmateus@suse.com>
+
+- version 0.0.4
+- hidden dot sub-command
+
+-------------------------------------------------------------------
+Tue May 25 06:11:50 UTC 2021 - Abid Mehmood <amehmood@suse.com>
+
+- version 0.0.1
+- Import and Export tools for ISS v2

--- a/inter-server-sync.spec
+++ b/inter-server-sync.spec
@@ -1,0 +1,109 @@
+#
+# spec file for package uyuni inter server sync
+#
+# Copyright (c) 2022 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+%if 0%{?rhel} == 8
+%global debug_package %{nil}
+%endif
+%if 0%{?rhel}
+# Fix ERROR: No build ID note found in
+%undefine _missing_build_ids_terminate_build
+%endif
+
+%global provider        github
+%global provider_tld    com
+%global org             uyuni-project
+%global project         inter-server-sync
+%global provider_prefix %{provider}.%{provider_tld}/%{org}/%{project}
+
+
+Name:           %{project}
+Version:        0.0.0
+Release:        0
+Summary:        Export/import data on a uyuni server
+License:        Apache-2.0
+Group:          System/Management
+URL:            https://%{provider_prefix}
+Source0:        %{name}-%{version}.tar.gz
+Source1:        vendor.tar.gz
+BuildRequires:  golang-packaging
+%if 0%{?rhel}
+BuildRequires:  golang >= 1.14
+%else
+BuildRequires:  golang(API) = 1.14
+%endif
+BuildRequires:  rsyslog
+
+Requires:       logrotate
+Requires:       rsyslog
+Requires:       systemd
+
+
+%description
+Uyuni inter server sync tool
+Used to export content from one server and import it in a target server.
+
+%prep
+%autosetup
+tar -zxf %{SOURCE1}
+
+
+%build
+export GOFLAGS=-mod=vendor
+%goprep %{provider_prefix}
+%gobuild ...
+
+%install
+%goinstall
+%gosrc
+
+%gofilelist
+
+%define _release_dir  %{_builddir}/%{project}-%{version}/release
+
+
+# Add config files for hub
+install -d -m 0750 %{buildroot}%{_var}/log/hub
+
+# Add syslog config to redirect logs to /var/log/hub/iss2.log
+install -D -m 0644 %{_release_dir}/hub-iss-syslogs.conf %{buildroot}%{_sysconfdir}/rsyslog.d/hub-iss.conf
+
+#logrotate config
+install -D -m 0644 %{_release_dir}/hub-iss-logrotate.conf %{buildroot}%{_sysconfdir}/logrotate.d/inter-server-sync
+
+%check
+%if 0%{?rhel}
+# Fix OBS debug_package execution.
+rm -f %{buildroot}/usr/lib/debug/%{_bindir}/%{name}-%{version}-*.debug
+%endif
+
+%post
+%if 0%{?rhel}
+%systemd_postun rsyslog.service
+%else
+%service_del_postun rsyslog.service
+%endif
+
+%files -f file.lst
+
+%defattr(-,root,root)
+%doc README.md
+%license LICENSE
+%{_bindir}/inter-server-sync
+
+%config(noreplace) %{_sysconfdir}/rsyslog.d/hub-iss.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/inter-server-sync
+
+%changelog


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

We are moving the changes and spec file from OBS to git, and get it automatically downloaded from git.

OBS project: https://build.opensuse.org/package/show/systemsmanagement:Uyuni:Master/inter-server-sync