### PR TITLE
Correct sequence in use for table rhnpackagekey(bsc#1197400)

### DIFF
--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,3 +1,6 @@
+- version 0.2.1
+  * Correct sequence in use for table rhnpackagekey(bsc#1197400)
+
 -------------------------------------------------------------------
 Wed Apr  6 17:06:47 UTC 2022 - Ricardo Mateus <rmateus@suse.com>
 

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -23,6 +23,8 @@ func applyTableFilters(table Table) Table {
 		table.PKSequence = "rhn_pkgnevra_id_seq"
 	case "rhnpackagesource":
 		table.PKSequence = "rhn_package_source_id_seq"
+	case "rhnpackagekey":
+		table.PKSequence = "rhn_pkey_id_seq"
 	case "rhnpackageevr":
 		// constraint: rhn_pe_id_pk
 		table.PKSequence = "rhn_pkg_evr_seq"


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>
Correct the sequence name for table rhnpackagekey