### PR TITLE
Parameter --channel-with-children didn't export data(bsc#1199089)

### DIFF
--- a/entityDumper/dumper.go
+++ b/entityDumper/dumper.go
@@ -24,7 +24,7 @@ func DumpAllEntities(options DumperOptions) {
 	db := schemareader.GetDBconnection(options.ServerConfig)
 	defer db.Close()
 	bufferWriter.WriteString("BEGIN;\n")
-	if len(options.ChannelLabels) > 0 {
+	if len(options.ChannelLabels) > 0 || len(options.ChannelWithChildrenLabels) > 0 {
 		processAndInsertProducts(db, bufferWriter)
 		processAndInsertChannels(db, bufferWriter, options)
 	}

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,3 +1,6 @@
+- version 0.2.2
+  * Parameter --channel-with-children didn't export data(bsc#1199089)
+
 -------------------------------------------------------------------
 Fri Apr 22 09:21:52 UTC 2022 - Ricardo Mateus <rmateus@suse.com>
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

Implementation of: https://github.com/SUSE/spacewalk/issues/17722

Parameter --channel-with-children was not used to verify if we should export channels. Now we check and export data with it.