### PR TITLE
1202785 -  rhnerratafile error insert

### DIFF
--- a/dumper/crawler_test.go
+++ b/dumper/crawler_test.go
@@ -36,16 +36,16 @@ func TestShouldCreateDataDumper(t *testing.T) {
 	testCase := createDataCrawlerTestCase(graph, root)
 
 	// the data repository expect these statements in the exact same order
-	testCase.repo.Expect("SELECT * FROM root WHERE CUSTOM ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v31 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v32 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v33 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v34 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v35 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v36 WHERE id = $1;", 1)
+	testCase.repo.Expect("SELECT * FROM root WHERE CUSTOM ;", testCase.schemaMetadata["root"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v35_fk_id, v36_fk_id FROM v31 WHERE id = $1;", testCase.schemaMetadata["v31"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v33_fk_id FROM v32 WHERE id = $1;", testCase.schemaMetadata["v32"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v34_fk_id FROM v33 WHERE id = $1;", testCase.schemaMetadata["v33"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v35_fk_id, v36_fk_id FROM v34 WHERE id = $1;", testCase.schemaMetadata["v34"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v34_fk_id FROM v35 WHERE id = $1;", testCase.schemaMetadata["v35"].Columns, 1)
+	testCase.repo.Expect("SELECT id FROM v36 WHERE id = $1;", testCase.schemaMetadata["v36"].Columns, 1)
 
-	testCase.repo.Expect("SELECT id, fk_id FROM v35 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v36 WHERE id = $1;", 1)
+	testCase.repo.Expect("SELECT id, v34_fk_id FROM v35 WHERE id = $1;", testCase.schemaMetadata["v35"].Columns, 1)
+	testCase.repo.Expect("SELECT id FROM v36 WHERE id = $1;", testCase.schemaMetadata["v36"].Columns, 1)
 
 	// Act
 	dataDumper := DataCrawler(

--- a/dumper/writer_test.go
+++ b/dumper/writer_test.go
@@ -42,17 +42,17 @@ func TestPrintAllTableData(t *testing.T) {
 	testCase := createTestCase(graph, root, PrintSqlOptions{})
 
 	// the data repository expect these statements in the exact same order
-	testCase.repo.Expect("SELECT id, fk_id FROM v04 ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v05 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v05 ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v04 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v01 ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v03 ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v02 ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v03 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM root ;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v01 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v02 WHERE id = $1;", 1)
+	testCase.repo.Expect("SELECT id, v05_fk_id FROM v04 ;", testCase.schemaMetadata["v04"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v04_fk_id FROM v05 WHERE id = $1;", testCase.schemaMetadata["v05"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v04_fk_id FROM v05 ;", testCase.schemaMetadata["v05"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v05_fk_id FROM v04 WHERE id = $1;", testCase.schemaMetadata["v04"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v05_fk_id FROM v01 ;", testCase.schemaMetadata["v01"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v04_fk_id FROM v03 ;", testCase.schemaMetadata["v03"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v03_fk_id FROM v02 ;", testCase.schemaMetadata["v02"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v04_fk_id FROM v03 WHERE id = $1;", testCase.schemaMetadata["v03"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v01_fk_id, v02_fk_id FROM root ;", testCase.schemaMetadata["root"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v05_fk_id FROM v01 WHERE id = $1;", testCase.schemaMetadata["v01"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v03_fk_id FROM v02 WHERE id = $1;", testCase.schemaMetadata["v02"].Columns, 1)
 
 	// 02 Act
 	result := processTableDataWithLinks(
@@ -107,104 +107,104 @@ func TestPrintCleanTables(t *testing.T) {
 		PrintSqlOptions{TablesToClean: keys},
 	)
 
-	testCase.repo.Expect("SELECT * FROM root WHERE (id) IN (SELECT root.id FROM root  );", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v11 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v12 WHERE id = $1;", 1)
+	testCase.repo.Expect("SELECT * FROM root WHERE (id) IN (SELECT root.id FROM root  );", testCase.schemaMetadata["root"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v15_fk_id, v16_fk_id FROM v11 WHERE id = $1;", testCase.schemaMetadata["v11"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v13_fk_id FROM v12 WHERE id = $1;", testCase.schemaMetadata["v12"].Columns, 1)
 	testCase.repo.Expect("SELECT * FROM v11 WHERE (id) IN (SELECT v11.id FROM v11  "+
-		"INNER JOIN root on root.fk_id = v11.id );", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v15 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v16 WHERE id = $1;", 1)
+		"INNER JOIN root on root.v11_fk_id = v11.id );", testCase.schemaMetadata["v11"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v14_fk_id FROM v15 WHERE id = $1;", testCase.schemaMetadata["v15"].Columns, 1)
+	testCase.repo.Expect("SELECT id FROM v16 WHERE id = $1;", testCase.schemaMetadata["v16"].Columns, 1)
 	testCase.repo.Expect("SELECT * FROM v15 WHERE (id) IN (SELECT v15.id FROM v15  "+
-		"INNER JOIN v11 on v11.fk_id = v15.id "+
-		"INNER JOIN root on root.fk_id = v11.id );", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v14 WHERE id = $1;", 1)
+		"INNER JOIN v11 on v11.v15_fk_id = v15.id "+
+		"INNER JOIN root on root.v11_fk_id = v11.id );", testCase.schemaMetadata["v15"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v15_fk_id, v16_fk_id FROM v14 WHERE id = $1;", testCase.schemaMetadata["v14"].Columns, 1)
 	testCase.repo.Expect("SELECT * FROM v14 WHERE (id) IN (SELECT v14.id FROM v14  "+
-		"INNER JOIN v15 on v15.fk_id = v14.id "+
-		"INNER JOIN v11 on v11.fk_id = v15.id "+
-		"INNER JOIN root on root.fk_id = v11.id );", 1)
+		"INNER JOIN v15 on v15.v14_fk_id = v14.id "+
+		"INNER JOIN v11 on v11.v15_fk_id = v15.id "+
+		"INNER JOIN root on root.v11_fk_id = v11.id );", testCase.schemaMetadata["v14"].Columns, 1)
 	testCase.repo.Expect("SELECT * FROM v16 WHERE (id) IN (SELECT v16.id FROM v16  "+
-		"INNER JOIN v14 on v14.fk_id = v16.id "+
-		"INNER JOIN v15 on v15.fk_id = v14.id "+
-		"INNER JOIN v11 on v11.fk_id = v15.id "+
-		"INNER JOIN root on root.fk_id = v11.id );", 1)
+		"INNER JOIN v14 on v14.v16_fk_id = v16.id "+
+		"INNER JOIN v15 on v15.v14_fk_id = v14.id "+
+		"INNER JOIN v11 on v11.v15_fk_id = v15.id "+
+		"INNER JOIN root on root.v11_fk_id = v11.id );", testCase.schemaMetadata["v16"].Columns, 1)
 	testCase.repo.Expect("SELECT * FROM v12 WHERE (id) IN (SELECT v12.id FROM v12  "+
-		"INNER JOIN root on root.fk_id = v12.id );", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v13 WHERE id = $1;", 1)
+		"INNER JOIN root on root.v12_fk_id = v12.id );", testCase.schemaMetadata["v12"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v14_fk_id FROM v13 WHERE id = $1;", testCase.schemaMetadata["v13"].Columns, 1)
 	testCase.repo.Expect("SELECT * FROM v13 WHERE (id) IN (SELECT v13.id FROM v13  "+
-		"INNER JOIN v12 on v12.fk_id = v13.id "+
-		"INNER JOIN root on root.fk_id = v12.id );", 1)
+		"INNER JOIN v12 on v12.v13_fk_id = v13.id "+
+		"INNER JOIN root on root.v12_fk_id = v12.id );", testCase.schemaMetadata["v13"].Columns, 1)
 
 	expectedWrittenBuffer := []string{
 		"" +
 			"\n" +
 			"DELETE FROM root WHERE (id) IN (SELECT root.id FROM root  );" +
 			"\n" +
-			"INSERT INTO root (id, fk_id)\t" +
-			"SELECT (SELECT id FROM v12 WHERE id = '0001' LIMIT 1),'0001' " +
-			"WHERE NOT EXISTS (SELECT 1 FROM root WHERE  id = (SELECT id FROM v12 WHERE id = '0001' LIMIT 1))" +
-			" AND EXISTS (SELECT id FROM v12 WHERE id = '0001' LIMIT 1);" +
+			"INSERT INTO root (id, v11_fk_id, v12_fk_id)\t" +
+			"SELECT '0001',(SELECT id FROM v11 WHERE id = '0001' LIMIT 1),(SELECT id FROM v12 WHERE id = '0001' LIMIT 1) " +
+			"WHERE NOT EXISTS (SELECT 1 FROM root WHERE  id = '0001')" +
+			" AND EXISTS (SELECT id FROM v11 WHERE id = '0001' LIMIT 1) AND EXISTS (SELECT id FROM v12 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
-			"DELETE FROM v11 WHERE (id) IN (SELECT v11.id FROM v11  INNER JOIN root on root.fk_id = v11.id );" +
+			"DELETE FROM v11 WHERE (id) IN (SELECT v11.id FROM v11  INNER JOIN root on root.v11_fk_id = v11.id );" +
 			"\n" +
-			"INSERT INTO v11 (id, fk_id)\t" +
-			"SELECT (SELECT id FROM v16 WHERE id = '0001' LIMIT 1),'0001' " +
-			"WHERE NOT EXISTS (SELECT 1 FROM v11 WHERE  id = (SELECT id FROM v16 WHERE id = '0001' LIMIT 1)) " +
-			"AND EXISTS (SELECT id FROM v16 WHERE id = '0001' LIMIT 1);" +
+			"INSERT INTO v11 (id, v15_fk_id, v16_fk_id)\t" +
+			"SELECT '0001',(SELECT id FROM v15 WHERE id = '0001' LIMIT 1),(SELECT id FROM v16 WHERE id = '0001' LIMIT 1) " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v11 WHERE  id = '0001') " +
+			"AND EXISTS (SELECT id FROM v15 WHERE id = '0001' LIMIT 1) AND EXISTS (SELECT id FROM v16 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v15 WHERE (id) IN " +
-			"(SELECT v15.id FROM v15  INNER JOIN v11 on v11.fk_id = v15.id INNER JOIN root on root.fk_id = v11.id );" +
+			"(SELECT v15.id FROM v15  INNER JOIN v11 on v11.v15_fk_id = v15.id INNER JOIN root on root.v11_fk_id = v11.id );" +
 			"\n" +
-			"INSERT INTO v15 (id, fk_id)\t" +
-			"SELECT (SELECT id FROM v14 WHERE id = '0001' LIMIT 1),'0001' " +
-			"WHERE NOT EXISTS (SELECT 1 FROM v15 WHERE  id = (SELECT id FROM v14 WHERE id = '0001' LIMIT 1)) " +
+			"INSERT INTO v15 (id, v14_fk_id)\t" +
+			"SELECT '0001',(SELECT id FROM v14 WHERE id = '0001' LIMIT 1) " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v15 WHERE  id = '0001') " +
 			"AND EXISTS (SELECT id FROM v14 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v14 WHERE (id) IN " +
 			"(SELECT v14.id FROM v14  " +
-			"INNER JOIN v15 on v15.fk_id = v14.id " +
-			"INNER JOIN v11 on v11.fk_id = v15.id " +
-			"INNER JOIN root on root.fk_id = v11.id );" +
+			"INNER JOIN v15 on v15.v14_fk_id = v14.id " +
+			"INNER JOIN v11 on v11.v15_fk_id = v15.id " +
+			"INNER JOIN root on root.v11_fk_id = v11.id );" +
 			"\n" +
-			"INSERT INTO v14 (id, fk_id)\t" +
-			"SELECT (SELECT id FROM v16 WHERE id = '0001' LIMIT 1),'0001' " +
-			"WHERE NOT EXISTS (SELECT 1 FROM v14 WHERE  id = (SELECT id FROM v16 WHERE id = '0001' LIMIT 1)) " +
-			"AND EXISTS (SELECT id FROM v16 WHERE id = '0001' LIMIT 1);" +
+			"INSERT INTO v14 (id, v15_fk_id, v16_fk_id)\t" +
+			"SELECT '0001',(SELECT id FROM v15 WHERE id = '0001' LIMIT 1),(SELECT id FROM v16 WHERE id = '0001' LIMIT 1) " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v14 WHERE  id = '0001') " +
+			"AND EXISTS (SELECT id FROM v15 WHERE id = '0001' LIMIT 1) AND EXISTS (SELECT id FROM v16 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v16 WHERE (id) IN " +
 			"(SELECT v16.id FROM v16  " +
-			"INNER JOIN v14 on v14.fk_id = v16.id " +
-			"INNER JOIN v15 on v15.fk_id = v14.id " +
-			"INNER JOIN v11 on v11.fk_id = v15.id " +
-			"INNER JOIN root on root.fk_id = v11.id );" +
+			"INNER JOIN v14 on v14.v16_fk_id = v16.id " +
+			"INNER JOIN v15 on v15.v14_fk_id = v14.id " +
+			"INNER JOIN v11 on v11.v15_fk_id = v15.id " +
+			"INNER JOIN root on root.v11_fk_id = v11.id );" +
 			"\n" +
-			"INSERT INTO v16 (id, fk_id)\t" +
-			"SELECT '0001','0001' " +
+			"INSERT INTO v16 (id)\t" +
+			"SELECT '0001' " +
 			"WHERE NOT EXISTS (SELECT 1 FROM v16 WHERE  id = '0001') " +
 			"AND ;" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v12 WHERE (id) IN " +
 			"(SELECT v12.id FROM v12  " +
-			"INNER JOIN root on root.fk_id = v12.id );" +
+			"INNER JOIN root on root.v12_fk_id = v12.id );" +
 			"\n" +
-			"INSERT INTO v12 (id, fk_id)\t" +
-			"SELECT (SELECT id FROM v13 WHERE id = '0001' LIMIT 1),'0001' " +
-			"WHERE NOT EXISTS (SELECT 1 FROM v12 WHERE  id = (SELECT id FROM v13 WHERE id = '0001' LIMIT 1)) " +
+			"INSERT INTO v12 (id, v13_fk_id)\t" +
+			"SELECT '0001',(SELECT id FROM v13 WHERE id = '0001' LIMIT 1) " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v12 WHERE  id = '0001') " +
 			"AND EXISTS (SELECT id FROM v13 WHERE id = '0001' LIMIT 1);" +
 			"\n" +
 			"\n" +
 			"DELETE FROM v13 WHERE (id) IN " +
 			"(SELECT v13.id FROM v13  " +
-			"INNER JOIN v12 on v12.fk_id = v13.id " +
-			"INNER JOIN root on root.fk_id = v12.id );" +
+			"INNER JOIN v12 on v12.v13_fk_id = v13.id " +
+			"INNER JOIN root on root.v12_fk_id = v12.id );" +
 			"\n" +
-			"INSERT INTO v13 (id, fk_id)\t" +
-			"SELECT (SELECT id FROM v14 WHERE id = '0001' LIMIT 1),'0001' " +
-			"WHERE NOT EXISTS (SELECT 1 FROM v13 WHERE  id = (SELECT id FROM v14 WHERE id = '0001' LIMIT 1)) " +
+			"INSERT INTO v13 (id, v14_fk_id)\t" +
+			"SELECT '0001',(SELECT id FROM v14 WHERE id = '0001' LIMIT 1) " +
+			"WHERE NOT EXISTS (SELECT 1 FROM v13 WHERE  id = '0001') " +
 			"AND EXISTS (SELECT id FROM v14 WHERE id = '0001' LIMIT 1);" +
 			"\n",
 	}
@@ -261,19 +261,19 @@ func TestPrintTableData(t *testing.T) {
 	testCase := createTestCase(graph, root, PrintSqlOptions{PostOrderCallback: createCallback()})
 
 	// the data repository expect these statements in the exact same order
-	testCase.repo.Expect("SELECT id, fk_id FROM v26 WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v24 WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v25 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v26 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v25 WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v24 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v21 WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v23 WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v22 WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v23 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM root WHERE (id) IN (('0001'));", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v21 WHERE id = $1;", 1)
-	testCase.repo.Expect("SELECT id, fk_id FROM v22 WHERE id = $1;", 1)
+	testCase.repo.Expect("SELECT id FROM v26 WHERE (id) IN (('0001'));", testCase.schemaMetadata["v26"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v25_fk_id, v26_fk_id FROM v24 WHERE (id) IN (('0001'));", testCase.schemaMetadata["v24"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v24_fk_id FROM v25 WHERE id = $1;", testCase.schemaMetadata["v25"].Columns, 1)
+	testCase.repo.Expect("SELECT id FROM v26 WHERE id = $1;", testCase.schemaMetadata["v26"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v24_fk_id FROM v25 WHERE (id) IN (('0001'));", testCase.schemaMetadata["v25"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v25_fk_id, v26_fk_id FROM v24 WHERE id = $1;", testCase.schemaMetadata["v24"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v25_fk_id, v26_fk_id FROM v21 WHERE (id) IN (('0001'));", testCase.schemaMetadata["v21"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v24_fk_id FROM v23 WHERE (id) IN (('0001'));", testCase.schemaMetadata["v23"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v23_fk_id FROM v22 WHERE (id) IN (('0001'));", testCase.schemaMetadata["v22"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v24_fk_id FROM v23 WHERE id = $1;", testCase.schemaMetadata["v23"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v21_fk_id, v22_fk_id FROM root WHERE (id) IN (('0001'));", testCase.schemaMetadata["root"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v25_fk_id, v26_fk_id FROM v21 WHERE id = $1;", testCase.schemaMetadata["v21"].Columns, 1)
+	testCase.repo.Expect("SELECT id, v23_fk_id FROM v22 WHERE id = $1;", testCase.schemaMetadata["v22"].Columns, 1)
 
 	// 02 Act
 	orderedTables := getTablesExportOrder(testCase.schemaMetadata, testCase.startingTable, testCase.processedTables, testCase.path)

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,5 +1,5 @@
 * Improve memory usage and log information #17193
-
+* Conditional insert check for foreign key reference exists(bsc#1202785)
 
 -------------------------------------------------------------------
 Thu Jul 21 11:21:25 UTC 2022 - Artem Shiliaev <artem.shiliaev@suse.com>

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,5 +1,6 @@
 * Improve memory usage and log information #17193
 * Conditional insert check for foreign key reference exists(bsc#1202785)
+* Correct navigation path for table rhnerratafilechannel(bsc#1202785)
 
 -------------------------------------------------------------------
 Thu Jul 21 11:21:25 UTC 2022 - Artem Shiliaev <artem.shiliaev@suse.com>

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -111,6 +111,10 @@ func applyTableFilters(table Table) Table {
 		virtualIndexColumns := []string{"profile_id", "path"}
 		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
 		table.MainUniqueIndexName = VirtualIndexName
+	case "rhnerrata":
+		// this table has two unique indexes with the same size which can be used
+		// we are fixing the usage to one of them to make it deterministic
+		table.MainUniqueIndexName = "rhn_errata_adv_org_uq"
 	}
 
 	return table

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+
 	"github.com/DATA-DOG/go-sqlmock"
 )
 
@@ -28,14 +29,18 @@ func CreateDataRepository() *DataRepository {
 }
 
 // Expect adds data to repository, which can then be retrieved by the tested function.
-func (repo *DataRepository) Expect(stm string, numRecords int, args ...driver.Value) {
+func (repo *DataRepository) Expect(stm string, columns []string, numRecords int, args ...driver.Value) {
 
 	// simulate table having only one row
 	recs := sqlmock.
-		NewRows([]string{"id", "fk_id"})
+		NewRows(columns)
 
 	for i := 0; i < numRecords; i++ {
-		recs = recs.AddRow(fmt.Sprintf("%04d", i+1), fmt.Sprintf("%04d", 1))
+		res := []driver.Value{fmt.Sprintf("%04d", i+1)}
+		for j := 1; j < len(columns); j++ {
+			res = append(res, fmt.Sprintf("%04d", 1))
+		}
+		recs = recs.AddRow(res...)
 	}
 	// add mock expectation
 	if len(args) > 0 {


### PR DESCRIPTION
implementation of: https://github.com/SUSE/spacewalk/issues/18767

In the tables clean generate step the insert statement needs to check if the target link table references are already present.
We were doing if just for the Unique Main constraint and not checking other foreign keys. This was fine for all tables except the rhnerratafile table.

This table has a link to rhnchecksum with is not part of the main unique index.

With this change, we keep adding all the columns in the main Unique index. After this is enhanced by adding a check for all checks.
 
An alternative implementation would be to ignore the main unique index and just add all refereces.
