### PR TITLE
Correct error with import without debug flag which fails on rsync

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -99,13 +99,15 @@ func runPackageFileSync(absImportDir string) {
 		}
 	}
 
-	debugFlag := ""
+	rsyncParams := make([]string, 0)
 	if log.Debug().Enabled() {
-		debugFlag = "-v"
+		rsyncParams = append(rsyncParams, "-v")
 	}
 
-	cmd := exec.Command("rsync", debugFlag, "-og", "--chown=wwwrun:www", "-r",
+	rsyncParams = append(rsyncParams, "-og", "--chown=wwwrun:www", "-r",
 		packagesImportDir, "/var/spacewalk/packages/")
+
+	cmd := exec.Command("rsync", rsyncParams...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	log.Info().Msg("starting importing package files")
@@ -132,13 +134,14 @@ func runImageFileSync(absImportDir string, serverFQDN string) {
 		}
 	}
 
-	debugFlag := ""
+	rsyncParams := make([]string, 0)
 	if log.Debug().Enabled() {
-		debugFlag = "-v"
+		rsyncParams = append(rsyncParams, "-v")
 	}
-
-	cmd := exec.Command("rsync", debugFlag, "-og", "--chown=salt:susemanager", "--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r",
+	rsyncParams = append(rsyncParams, "-og", "--chown=salt:susemanager", "--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r",
 		"-r", "--exclude=pillars", imagesImportDir+"/", "/srv/www/os-images")
+
+	cmd := exec.Command("rsync", rsyncParams...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	log.Info().Msg("Copying image files")

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,3 +1,5 @@
+* Correct error when importing without debug log level (bsc#1204699)
+
 -------------------------------------------------------------------
 Wed Oct 12 10:31:36 UTC 2022 - Ricardo Mateus <rmateus@suse.com>
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

When running import without log level debug the debug flag was not added to the rsync call and the go command fails.

fix: https://github.com/SUSE/spacewalk/issues/19333