### PR TITLE
update go build version to 18 and openssl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/uyuni-project/inter-server-sync
 
-go 1.17
+go 1.18
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,4 +1,5 @@
 * Correct error when importing without debug log level (bsc#1204699)
+* Change build to use go version 18 with openssl (#19269)
 
 -------------------------------------------------------------------
 Wed Oct 12 10:31:36 UTC 2022 - Ricardo Mateus <rmateus@suse.com>

--- a/inter-server-sync.spec
+++ b/inter-server-sync.spec
@@ -40,9 +40,13 @@ Source0:        %{name}-%{version}.tar.gz
 Source1:        vendor.tar.gz
 BuildRequires:  golang-packaging
 %if 0%{?rhel}
-BuildRequires:  golang >= 1.16
+BuildRequires:  golang >= 1.17
 %else
-BuildRequires:  golang(API) = 1.16
+%if 0%{?is_opensuse}
+BuildRequires:  golang(API) = 1.18
+%else
+BuildRequires:  go1.18-openssl
+%endif
 %endif
 BuildRequires:  rsyslog
 
@@ -68,9 +72,6 @@ export GOFLAGS=-mod=vendor
 
 %install
 %goinstall
-%gosrc
-
-%gofilelist
 
 %define _release_dir  %{_builddir}/%{project}-%{version}/release
 
@@ -97,7 +98,7 @@ rm -f %{buildroot}/usr/lib/debug/%{_bindir}/%{name}-%{version}-*.debug
 %service_del_postun rsyslog.service
 %endif
 
-%files -f file.lst
+%files
 
 %defattr(-,root,root)
 %doc README.md


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

Change the build process to use go18_openssl package to build.
Implements: https://github.com/SUSE/spacewalk/issues/19269