### PR TITLE
Translate image pillars URLs when in 4.3 and newer

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"os"
 	"path"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -43,9 +42,7 @@ func init() {
 }
 
 func runExport(cmd *cobra.Command, args []string) {
-	log.Debug().Msg("export called")
-	log.Debug().Msg(strings.Join(channels, ","))
-	log.Debug().Msg(outputDir)
+	log.Info().Msg("Export started")
 	// check output dir existence and create it if needed.
 
 	// Validate data

--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -32,7 +32,8 @@ func PrintTableDataOrdered(db *sql.DB, writer *bufio.Writer, schemaMetadata map[
 	cache = make(map[string]string)
 }
 
-/**
+/*
+*
 clear tables need to be printed in reverse order, otherwise it will not work
 */
 func printCleanTables(db *sql.DB, writer *bufio.Writer, schemaMetadata map[string]schemareader.Table, table schemareader.Table,
@@ -220,7 +221,8 @@ func GetRowsFromKeys(db *sql.DB, table schemareader.Table, keys []TableKey) [][]
 
 func filterRowData(value []sqlUtil.RowDataStructure, table schemareader.Table) []sqlUtil.RowDataStructure {
 	if table.RowModCallback != nil {
-		value = table.RowModCallback(value, table)
+		// value passed as slice so modifications done in callback are visible in this scope as well
+		table.RowModCallback(value, table)
 	}
 	if table.UnexportColumns != nil {
 		returnValues := make([]sqlUtil.RowDataStructure, 0)

--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -219,12 +219,8 @@ func GetRowsFromKeys(db *sql.DB, table schemareader.Table, keys []TableKey) [][]
 }
 
 func filterRowData(value []sqlUtil.RowDataStructure, table schemareader.Table) []sqlUtil.RowDataStructure {
-	if strings.Compare(table.Name, "rhnerrata") == 0 {
-		for i, row := range value {
-			if strings.Compare(row.ColumnName, "severity_id") == 0 {
-				value[i].Value = value[i].GetInitialValue()
-			}
-		}
+	if table.RowModCallback != nil {
+		value = table.RowModCallback(value, table)
 	}
 	if table.UnexportColumns != nil {
 		returnValues := make([]sqlUtil.RowDataStructure, 0)

--- a/dumper/pillarDumper/pillarDumper.go
+++ b/dumper/pillarDumper/pillarDumper.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/inter-server-sync/dumper"
@@ -76,9 +77,10 @@ func DumpPillars(sourceDir, outputDir, sourceFQDN, targetFQDN string) {
 	}
 }
 
-func ImportImagePillars(sourceDir string, serverConfig string) {
+// 4.2 and older stores pillars in files
+// image export replaces hostnames in image pillars, we need to replace them to correct SUMA on import
+func ImportImagePillars(sourceDir string, fqdn string) {
 	log.Debug().Msgf("Importing image pillars from %s", sourceDir)
-	fqdn := utils.GetCurrentServerFQDN(serverConfig)
 	orgDir, err := os.Open(sourceDir)
 	if err != nil {
 		log.Fatal().Err(err)
@@ -100,5 +102,24 @@ func ImportImagePillars(sourceDir string, serverConfig string) {
 
 			}
 		}
+	}
+}
+
+// 4.3 and newer stores pillars in database
+// image export replaces hostnames in image pillars, we need to replace them to correct SUMA on import
+func UpdateImagePillars(fqdn string) {
+	cmd := exec.Command("spacewalk-sql", "-")
+	sqlQuery := fmt.Sprintf("UPDATE susesaltpillar SET pillar = REPLACE(pillar::text, '%s', '%s')::jsonb WHERE category LIKE Image%%;",
+		replacePattern, fqdn)
+
+	cmd.Stdin = strings.NewReader(sqlQuery)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	log.Info().Msg("Updating image pillars if needed")
+
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Error updating image pillars")
 	}
 }

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/uyuni-project/inter-server-sync/dumper"
@@ -126,6 +127,7 @@ var singleChannelSql = "select label from rhnchannel " +
 	"where label = $1"
 
 func loadChannelsToProcess(db *sql.DB, options DumperOptions) []string {
+	log.Trace().Msg("Loading channel list")
 	channels := channelsProcess{make(map[string]bool), make([]string, 0)}
 	for _, singleChannel := range options.ChannelLabels {
 		if _, ok := channels.channelsMap[singleChannel]; !ok {
@@ -154,10 +156,12 @@ func loadChannelsToProcess(db *sql.DB, options DumperOptions) []string {
 
 		}
 	}
+	log.Debug().Msgf("Channels to export: %s", strings.Join(channels.channels, ","))
 	return channels.channels
 }
 
 func processAndInsertProducts(db *sql.DB, writer *bufio.Writer) {
+	log.Trace().Msg("Processing product tables")
 	schemaMetadata := schemareader.ReadTablesSchema(db, ProductsTableNames())
 	startingTables := []schemareader.Table{schemaMetadata["suseproducts"]}
 

--- a/schemareader/types.go
+++ b/schemareader/types.go
@@ -1,5 +1,7 @@
 package schemareader
 
+import "github.com/uyuni-project/inter-server-sync/sqlUtil"
+
 // Table represents a DB table to dump
 type Table struct {
 	Name            string
@@ -14,6 +16,7 @@ type Table struct {
 	MainUniqueIndexName string
 	References          []Reference
 	ReferencedBy        []Reference
+	RowModCallback      TableCallback
 }
 
 // UniqueIndex represents an index among columns of a Table
@@ -27,6 +30,9 @@ type Reference struct {
 	TableName     string
 	ColumnMapping map[string]string
 }
+
+// Row modification callback function
+type TableCallback func(value []sqlUtil.RowDataStructure, table Table) []sqlUtil.RowDataStructure
 
 // we are returning just one reference, the first one which uses the column we want
 func (table *Table) GetFirstReferenceFromColumn(columnName string) Reference {


### PR DESCRIPTION
Fixes https://github.com/uyuni-project/inter-server-sync/issues/42

- refactor `filterRowData` table values modification to callback
- add URL translation for pillars stored in database
- export only successfully built images