### PR TITLE
Redo image pillar update to work with 4.2

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -213,7 +213,7 @@ func runImportSql(absImportDir string, serverConfig string) {
 		}
 	}
 
-	pillarDumper.UpdateImagePillars(utils.GetCurrentServerFQDN(serverConfig))
+	pillarDumper.UpdateImagePillars(serverConfig)
 
 	if hasConfigChannels(absImportDir) {
 		labels := utils.ReadFileByLine(fmt.Sprintf("%s/exportedConfigs.txt", absImportDir))


### PR DESCRIPTION
- Do not update pillar table if it does not exists in the database like in SUMA4.2
- Redo SQL opts to do in go instead of executing spacewalk-sql