### PR TITLE
Correct index sequence name for table rhnPackageExtraTagKey

### DIFF
--- a/inter-server-sync.changes
+++ b/inter-server-sync.changes
@@ -1,3 +1,5 @@
+* Correct index sequence name for table rhnPackageExtraTagKey
+
 -------------------------------------------------------------------
 Wed Aug  9 12:56:27 UTC 2023 - Witek Bedyk <witold.bedyk@suse.com>
 

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -161,6 +161,8 @@ func applyTableFilters(table Table) Table {
 		virtualIndexColumns := []string{"image_info_id", "file"}
 		table.UniqueIndexes[VirtualIndexName] = UniqueIndex{Name: VirtualIndexName, Columns: virtualIndexColumns}
 		table.MainUniqueIndexName = VirtualIndexName
+	case "rhnpackageextratagkey":
+		table.PKSequence = "rhn_package_extra_tags_keys_id_seq"
 	}
 	return table
 }


### PR DESCRIPTION
Correct the sequence name to use for table rhnPackageExtraTagKey.
The auto-discover will not work because it's expecting the sequence name to be `rhn_package_extra_tags_key_id_seq` but the sequence name is `rhn_package_extra_tags_keys_id_seq` (notice that it have "keys" instead of "key")