### PR TITLE
Fix conflict in rhnerratacve

### DIFF
--- a/dumper/dataWriter.go
+++ b/dumper/dataWriter.go
@@ -445,6 +445,19 @@ func formatOnConflict(row []sqlUtil.RowDataStructure, table schemareader.Table) 
 		} else {
 			constraint = "(advisory, org_id) WHERE org_id IS NOT NULL"
 		}
+	case "rhnerratacve":
+		var errataId interface{} = nil
+		for _, field := range row {
+			if strings.Compare(field.ColumnName, "errata_id") == 0 {
+				errataId = field.Value
+				break
+			}
+		}
+		if errataId == nil {
+			constraint = "(cve_id) WHERE errata_id IS NULL"
+		} else {
+			constraint = "(cve_id, errata_id) WHERE errata_id IS NOT NULL"
+		}
 	case "rhnpackageevr":
 		var epoch interface{} = nil
 		for _, field := range row {

--- a/inter-server-sync.changes.mbussolotto.errata_id_constraint
+++ b/inter-server-sync.changes.mbussolotto.errata_id_constraint
@@ -1,0 +1,1 @@
+- Fix conflict in rhnerratacve 


### PR DESCRIPTION
Fix for this error: 
```
2023-10-10 18:18:04.951 MDT susemanager susemanager [10169]ERROR:  null value in column "errata_id" of relation "rhnerratacve" violates not-null constraint
2023-10-10 18:18:04.951 MDT susemanager susemanager [10169]DETAIL:  Failing row contains (null, 931, 2023-10-09 17:34:56.101042-06, 2023-10-10 18:16:23.824787-06).
2023-10-10 18:18:04.951 MDT susemanager susemanager [10169]STATEMENT:  INSERT INTO rhnerratacve (errata_id, cve_id, created, modified)  VALUES ((SELECT id FROM rhnerrata WHERE advisory = 'CL-SUSE-15-SP4-2022-3767' AND org_id = (SELECT id FROM web_customer WHERE name = 'SUSE' LIMIT 1) LIMIT 1),(SELECT id FROM rhncve WHERE name = 'CVE-2022-2795' LIMIT 1),'2023-10-09 17:34:56.101042-06:00','2023-10-09 17:34:56.101042-06:00') ON CONFLICT (cve_id, errata_id) DO UPDATE SET errata_id = excluded.errata_id,cve_id = excluded.cve_id,created = excluded.created,modified = excluded.modified;

```

Last fixes for: https://github.com/SUSE/spacewalk/issues/22785