### PR TITLE
create channel parent/child relationship when importing parent

### DIFF
--- a/inter-server-sync.changes.rmateus.main
+++ b/inter-server-sync.changes.rmateus.main
@@ -1,0 +1,1 @@
+- create channel parent/child relationship when importing parent


### PR DESCRIPTION
When importing channels individually if the channel have some child channels it will not update the relationship automatically, and only at second import it will get updated.

the alternative to work around it it to make sure we first import the parent channel and then we can import all the child channels. 