### PR TITLE
Pin all GitHub actions to a commit

### DIFF
--- a/.github/workflows/github-actions-tests.yml
+++ b/.github/workflows/github-actions-tests.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 #v2.2.20
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
       - name: Test
         run: go test ./... -cover -race

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -18,6 +18,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v2
+      uses: fsfe/reuse-action@4f2804894b54004c8ed4b8a62b7c649e54a3aa4b #v2.0.0


### PR DESCRIPTION
# Description

One of the recommendations of the [Good security practices for using GitHub Actions features](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions?learn=getting_started).

For each action I went to the repository and used the last released version for the major version we were using, and specified the exact version with a comment.

Be aware some actions are deprecated and archived, and for others we are using old 2.x version while most recent are 4.x. Feel free to create a card to trck it.