### PR TITLE
Add signing of SQL export

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -5,11 +5,13 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path"
 
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/uyuni-project/inter-server-sync/dumper"
 	"github.com/uyuni-project/inter-server-sync/entityDumper"
 	"github.com/uyuni-project/inter-server-sync/utils"
 )
@@ -28,6 +30,8 @@ var metadataOnly bool
 var startingDate string
 var includeImages bool
 var includeContainers bool
+var signKey string
+var pubcert string
 var orgs []uint
 
 func init() {
@@ -40,6 +44,8 @@ func init() {
 	exportCmd.Flags().BoolVar(&includeImages, "images", false, "Export OS images and associated metadata")
 	exportCmd.Flags().BoolVar(&includeContainers, "containers", false, "Export containers metadata")
 	exportCmd.Flags().UintSliceVar(&orgs, "orgLimit", nil, "Export only for specified organizations")
+	exportCmd.Flags().StringVar(&signKey, "signKey", "/etc/pki/tls/private/spacewalk.key", "Private certificate used for signing the export")
+	exportCmd.Flags().StringVar(&pubcert, "certificate", "/etc/pki/tls/certs/spacewalk.crt", "Public certificate to be included in the export. Subject of CA validation during import")
 	exportCmd.Args = cobra.NoArgs
 
 	rootCmd.AddCommand(exportCmd)
@@ -55,6 +61,11 @@ func runExport(cmd *cobra.Command, args []string) {
 		log.Fatal().Msg("Unable to validate the date. Allowed formats are 'YYYY-MM-DD' or 'YYYY-MM-DD hh:mm:ss'")
 	}
 
+	// Validate we have signing key
+	if _, err := os.Stat(signKey); errors.Is(err, os.ErrNotExist) {
+		log.Fatal().Msg("Signing key does not exists. Please use `--signKey` to set key for export signing.")
+	}
+
 	options := entityDumper.DumperOptions{
 		ServerConfig:              serverConfig,
 		ChannelLabels:             channels,
@@ -66,8 +77,10 @@ func runExport(cmd *cobra.Command, args []string) {
 		OSImages:                  includeImages,
 		Containers:                includeContainers,
 		Orgs:                      orgs,
+		SignKey:                   signKey,
 	}
 	entityDumper.DumpAllEntities(options)
+
 	var versionfile string
 	versionfile = path.Join(utils.GetAbsPath(outputDir), "version.txt")
 	vf, err := os.Open(versionfile)
@@ -82,5 +95,9 @@ func runExport(cmd *cobra.Command, args []string) {
 	version, product := utils.GetCurrentServerVersion(serverConfig)
 	vf.WriteString("product_name = " + product + "\n" + "version = " + version + "\n")
 
+	// Collect public key of used signing key to the export. Will be CA validated during import
+	if _, err := dumper.Copy(pubcert, path.Join(utils.GetAbsPath(outputDir), "hubserver.pem")); err != nil {
+		log.Error().Err(err).Msg("failed to collect hub server public certificate. Manual selection will be needed on the import.")
+	}
 	log.Info().Msgf("Export done. Directory: %s", outputDir)
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -28,12 +28,18 @@ var importCmd = &cobra.Command{
 var importDir string
 var xmlRpcUser string
 var xmlRpcPassword string
+var skipVerify bool
+var certFile string
+var caFile string
 
 func init() {
 
 	importCmd.Flags().StringVar(&importDir, "importDir", ".", "Location import data from")
 	importCmd.Flags().StringVar(&xmlRpcUser, "xmlRpcUser", "admin", "A username to access the XML-RPC Api")
 	importCmd.Flags().StringVar(&xmlRpcPassword, "xmlRpcPassword", "admin", "A password to access the XML-RPC Api")
+	importCmd.Flags().BoolVar(&skipVerify, "skipVerify", false, "Skip verification of import signature")
+	importCmd.Flags().StringVar(&certFile, "verifyKey", "hubserver.pem", "Public certificate of signign hub server")
+	importCmd.Flags().StringVar(&caFile, "ca", "", "custom CA certificate chain for key validation")
 	importCmd.Args = cobra.NoArgs
 
 	rootCmd.AddCommand(importCmd)
@@ -47,7 +53,13 @@ func runImport(cmd *cobra.Command, args []string) {
 	if fversion != sversion || fproduct != sproduct {
 		log.Panic().Msgf("Wrong version detected. Fileversion = %s ; Serverversion = %s", fversion, sversion)
 	}
-	validateFolder(absImportDir)
+	sqlImportFile := validateFolder(absImportDir)
+	if !skipVerify {
+		if err := utils.ValidateFile(sqlImportFile, certFile, caFile); err != nil {
+			log.Fatal().Msg("Signature check of import file failed!")
+		}
+	}
+
 	runPackageFileSync(absImportDir)
 
 	runImageFileSync(absImportDir, serverConfig)
@@ -71,11 +83,13 @@ func getImportVersionProduct(path string) (string, string) {
 	return version, product
 }
 
-func validateFolder(absImportDir string) {
-	_, err := os.Stat(fmt.Sprintf("%s/sql_statements.sql.gz", absImportDir))
+func validateFolder(absImportDir string) string {
+	out := path.Join(absImportDir, "sql_statements.sql.gz")
+	_, err := os.Stat(out)
 	if err != nil {
 		if os.IsNotExist(err) {
-			_, err = os.Stat(fmt.Sprintf("%s/sql_statements.sql", absImportDir))
+			out = path.Join(absImportDir, "sql_statements.sql")
+			_, err = os.Stat(out)
 			if err != nil {
 				log.Fatal().Err(err).Msg("No usable .sql or .gz file found in import directory")
 			}
@@ -83,6 +97,7 @@ func validateFolder(absImportDir string) {
 			log.Fatal().Err(err)
 		}
 	}
+	return out
 }
 
 func hasConfigChannels(absImportDir string) bool {

--- a/entityDumper/types.go
+++ b/entityDumper/types.go
@@ -20,6 +20,7 @@ type DumperOptions struct {
 	Containers                bool
 	OSImages                  bool
 	Orgs                      []uint
+	SignKey                   string
 }
 
 func (opt *DumperOptions) GetOutputFolderAbsPath() string {

--- a/inter-server-sync.changes.oholecek.secured_export
+++ b/inter-server-sync.changes.oholecek.secured_export
@@ -1,0 +1,1 @@
+- Add SSL signed export and import validation (bsc#1241239)

--- a/inter-server-sync.spec
+++ b/inter-server-sync.spec
@@ -51,6 +51,7 @@ Requires:       gzip
 Requires:       logrotate
 Requires:       rsyslog
 Requires:       systemd
+Requires:       openssl
 
 %description
 Uyuni inter server sync tool


### PR DESCRIPTION
* export command extended by `--signKey` and `--certificate` options, defaults to spacewalk keys. Export SQL file is then signed by this key and cert is packaged together with export
* import command extended by `--verifyKey`, `--skip-verify` and `--ca` options. Verify key is first validated against CA, then SQL file signature is checked by verify key.

Public certificate for validating the export is included in the export and is validated by CA on import.
Optionally it is possible to pass different verification key on import, which too is validated by CA and custom CA option is also provided.

OpenSSL is added as a dependency of the ISSv2.

Issues: https://github.com/SUSE/spacewalk/issues/27004 and https://github.com/SUSE/spacewalk/issues/27015