### PR TITLE
Package /var/log/hub (bsc#1243724)

### DIFF
--- a/inter-server-sync.changes.mbussolotto.logdir
+++ b/inter-server-sync.changes.mbussolotto.logdir
@@ -1,0 +1,1 @@
+- Package /var/log/hub (bsc#1243724)

--- a/inter-server-sync.spec
+++ b/inter-server-sync.spec
@@ -94,6 +94,7 @@ rm -f %{buildroot}/usr/lib/debug/%{_bindir}/%{name}-%{version}-*.debug
 %endif
 
 %files -f file.lst
+%dir %attr(0750, root, root) %{_var}/log/hub
 
 %defattr(-,root,root)
 %doc README.md


### PR DESCRIPTION
logs are contained in `/var/log/hub`, but we're not listing the folder in the spec file

Issue: https://github.com/SUSE/spacewalk/issues/27352