### PR TITLE
rename suseproductsccrepository to susechanneltemplate (bsc#1244648)

### DIFF
--- a/dumper/dataCrawler.go
+++ b/dumper/dataCrawler.go
@@ -210,7 +210,7 @@ func shouldFollowReferenceToLink(path []string, currentTable schemareader.Table,
 	forcedNavigations := map[string][]string{
 		"rhnchannelfamily": {"rhnpublicchannelfamily"},
 		"rhnchannel":       {"susemddata", "suseproductchannel", "rhnreleasechannelmap", "rhndistchannelmap", "rhnerratafilechannel"},
-		"suseproducts":     {"suseproductextension", "suseproductsccrepository"},
+		"suseproducts":     {"suseproductextension", "susechanneltemplate"},
 		"rhnpackageevr":    {"rhnpackagenevra"},
 		"rhnerrata":        {"rhnerratafile"},
 		"rhnconfigchannel": {"rhnconfigfile"},

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -95,7 +95,7 @@ func ProductsTableNames() []string {
 		// product data tables
 		"suseproducts",             // clean
 		"suseproductextension",     // clean
-		"suseproductsccrepository", // clean
+		"susechanneltemplate", // clean
 		"susesccrepository",        // clean
 		"suseupgradepath",          // clean
 		// product data tables

--- a/inter-server-sync.changes.kwalter.raname_suseproductsccrepository
+++ b/inter-server-sync.changes.kwalter.raname_suseproductsccrepository
@@ -1,0 +1,1 @@
+- rename suseproductsccrepository to susechanneltemplate (bsc#1244648)

--- a/schemareader/tableFilters.go
+++ b/schemareader/tableFilters.go
@@ -18,8 +18,8 @@ const (
 
 func applyTableFilters(table Table) Table {
 	switch table.Name {
-	case "suseproductsccrepository":
-		table.PKSequence = "suse_prdrepo_id_seq"
+	case "susechanneltemplate":
+		table.PKSequence = "susechanneltemplate_id_seq"
 	case "rhnchecksumtype":
 		table.PKSequence = "rhn_checksum_id_seq"
 	case "rhnchecksum":


### PR DESCRIPTION
the suseproductsccrepository table was recently renamed to susechanneltemplate. This PR ports this change to inter-server-sync

https://github.com/uyuni-project/uyuni/commit/f5e34c46b173fbc468c57260290531b9b447de40#diff-bd6a9d1ce0009a1d5bf51f74269c845cc6cfb1252069519754f14e45749db1c3