### PR TITLE
Allow export without changelogdata (bsc#1245307)

### DIFF
--- a/cmd/export.go
+++ b/cmd/export.go
@@ -27,6 +27,7 @@ var channelWithChildren []string
 var configChannels []string
 var outputDir string
 var metadataOnly bool
+var nochangelog bool
 var startingDate string
 var includeImages bool
 var includeContainers bool
@@ -40,6 +41,7 @@ func init() {
 	exportCmd.Flags().StringSliceVar(&channelWithChildren, "channel-with-children", nil, "Channels to be exported")
 	exportCmd.Flags().StringVar(&outputDir, "outputDir", ".", "Location for generated data")
 	exportCmd.Flags().BoolVar(&metadataOnly, "metadataOnly", false, "export only metadata")
+	exportCmd.Flags().BoolVar(&nochangelog, "noChangelogs", false, "Skip exporting packages changelogs")
 	exportCmd.Flags().StringVar(&startingDate, "packagesOnlyAfter", "", "Only export packages added or modified after the specified date (date format can be 'YYYY-MM-DD' or 'YYYY-MM-DD hh:mm:ss')")
 	exportCmd.Flags().StringSliceVar(&configChannels, "configChannels", nil, "Configuration Channels to be exported")
 	exportCmd.Flags().BoolVar(&includeImages, "images", false, "Export OS images and associated metadata")
@@ -83,6 +85,7 @@ func runExport(cmd *cobra.Command, args []string) {
 		ChannelWithChildrenLabels: channelWithChildren,
 		OutputFolder:              outputDir,
 		MetadataOnly:              metadataOnly,
+		NoChangelogs:              nochangelog,
 		StartingDate:              validatedDate,
 		OSImages:                  includeImages,
 		Containers:                includeContainers,

--- a/entityDumper/channelDataDumper.go
+++ b/entityDumper/channelDataDumper.go
@@ -69,8 +69,6 @@ func SoftwareChannelTableNames() []string {
 		"rhnerratakeyword", // clean
 		"rhnpackagecapability",
 		"rhnpackagebreaks",
-		"rhnpackagechangelogdata",
-		"rhnpackagechangelogrec",
 		"rhnpackageconflicts",
 		"rhnpackageenhances",
 		"rhnpackageextratag",
@@ -188,7 +186,14 @@ func processAndInsertChannels(db *sql.DB, writer *bufio.Writer, options DumperOp
 	channels := loadChannelsToProcess(db, options)
 	log.Info().Msg(fmt.Sprintf("%d channels to process", len(channels)))
 
-	schemaMetadata := schemareader.ReadTablesSchema(db, SoftwareChannelTableNames())
+	channelTables := SoftwareChannelTableNames()
+	if !options.NoChangelogs {
+		channelTables = append(channelTables,
+			"rhnpackagechangelogdata",
+			"rhnpackagechangelogrec")
+	}
+
+	schemaMetadata := schemareader.ReadTablesSchema(db, channelTables)
 	log.Debug().Msg("channel schema metadata loaded")
 
 	fileChannels, err := os.Create(options.GetOutputFolderAbsPath() + "/exportedChannels.txt")

--- a/entityDumper/types.go
+++ b/entityDumper/types.go
@@ -16,6 +16,7 @@ type DumperOptions struct {
 	OutputFolder              string
 	outputFolderAbsPath       string
 	MetadataOnly              bool
+	NoChangelogs              bool
 	StartingDate              string
 	Containers                bool
 	OSImages                  bool

--- a/inter-server-sync.changes.oholecek.skip_changelogs
+++ b/inter-server-sync.changes.oholecek.skip_changelogs
@@ -1,0 +1,1 @@
+- Allow skipping changelog export (bsc#1245307)


### PR DESCRIPTION
Changelogs takes a significant amount of space and also increases export and import time.
This commit adds --noChangelogs option to skip exporting changelog data for packages.

Issue: https://github.com/SUSE/spacewalk/issues/27604