### PR TITLE
Fix recreating cobbler entries on import

### DIFF
--- a/cobbler/cobbler.go
+++ b/cobbler/cobbler.go
@@ -279,6 +279,10 @@ func createDistroEntry(image Image) error {
 
 // For each distro name this refreshes distro profile nameV and distro profile N to point to the latest versions
 func updateDistroProfiles(images []Image) error {
+	if len(images) == 0 {
+		log.Debug().Msg("No image to process, skipping")
+		return nil
+	}
 	imageMap := map[string]Image{}
 	var latestImage Image
 	// Get latest versions for each image name

--- a/cobbler/cobbler.go
+++ b/cobbler/cobbler.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -21,6 +22,11 @@ const (
 	COBBLER         = "/usr/bin/cobbler"
 	OS_STORE_PREFIX = "/srv/www/os-images"
 	DEFAULT_IMAGE   = "DEFAULT_IMAGE"
+)
+
+var (
+	nameRegexp = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
+	orgRegexp  = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 )
 
 // For unit testing
@@ -384,6 +390,8 @@ makeCobblerName returns custom saltboot name:
 	name:S:orgid:org
 */
 func makeCobblerName(inname string, org string, orgid string) string {
+	inname = sanitizeName(inname)
+	org = sanitizeOrg(org)
 	return strings.Join([]string{inname, "S", orgid, org}, ":")
 }
 
@@ -398,10 +406,24 @@ func makeCobblerNameVR(name string, version string, revision string, org string,
 		log.Error().Msg("Wrong call to the naming function. This is a bug")
 		return "", ""
 	}
+	name = sanitizeName(name)
+	version = sanitizeName(version)
+	revision = sanitizeName(revision)
+	org = sanitizeOrg(org)
+
 	nameVR := strings.Join([]string{name, version, revision}, "-")
 	nameVR = strings.Join([]string{nameVR, "S", orgid, org}, ":")
 	nameV := strings.Join([]string{name, version}, "-")
 	nameV = strings.Join([]string{nameV, "S", orgid, org}, ":")
 
 	return nameVR, nameV
+}
+
+func sanitizeName(s string) string {
+	s = strings.ReplaceAll(s, " ", "_")
+	return nameRegexp.ReplaceAllString(s, "")
+}
+
+func sanitizeOrg(s string) string {
+	return orgRegexp.ReplaceAllString(s, "")
 }

--- a/cobbler/cobbler_test.go
+++ b/cobbler/cobbler_test.go
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2025 SUSE LLC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cobbler
+
+import (
+	"testing"
+)
+
+func TestMakeCobblerName(t *testing.T) {
+	tests := []struct {
+		inname   string
+		org      string
+		orgid    string
+		expected string
+	}{
+		{"name", "org", "1", "name:S:1:org"},
+		{"name with spaces", "org with spaces", "1", "name_with_spaces:S:1:orgwithspaces"},
+		{"name!@#", "org!@#", "1", "name:S:1:org"},
+		{"name.dot", "org-dash", "1", "name.dot:S:1:org-dash"},
+	}
+
+	for _, tt := range tests {
+		result := makeCobblerName(tt.inname, tt.org, tt.orgid)
+		if result != tt.expected {
+			t.Errorf("makeCobblerName(%q, %q, %q) = %q, want %q", tt.inname, tt.org, tt.orgid, result, tt.expected)
+		}
+	}
+}
+
+func TestMakeCobblerNameVR(t *testing.T) {
+	tests := []struct {
+		name       string
+		version    string
+		revision   string
+		org        string
+		orgid      string
+		expectedVR string
+		expectedV  string
+	}{
+		{"name", "1.0", "1", "org", "1", "name-1.0-1:S:1:org", "name-1.0:S:1:org"},
+		{"name with spaces", "1.0", "1", "org with spaces", "1", "name_with_spaces-1.0-1:S:1:orgwithspaces", "name_with_spaces-1.0:S:1:orgwithspaces"},
+	}
+
+	for _, tt := range tests {
+		resVR, resV := makeCobblerNameVR(tt.name, tt.version, tt.revision, tt.org, tt.orgid)
+		if resVR != tt.expectedVR {
+			t.Errorf("makeCobblerNameVR(%q, %q, %q, %q, %q) VR = %q, want %q", tt.name, tt.version, tt.revision, tt.org, tt.orgid, resVR, tt.expectedVR)
+		}
+		if resV != tt.expectedV {
+			t.Errorf("makeCobblerNameVR(%q, %q, %q, %q, %q) V = %q, want %q", tt.name, tt.version, tt.revision, tt.org, tt.orgid, resV, tt.expectedV)
+		}
+	}
+}

--- a/inter-server-sync.changes.oholecek.fix_cobbler_imports
+++ b/inter-server-sync.changes.oholecek.fix_cobbler_imports
@@ -1,0 +1,5 @@
+- Add missing name sanitization for cobbler entries
+  (bsc#1259137)
+- Skip cobbler entries refresh if there are no images
+  (bsc#1257950)
+


### PR DESCRIPTION
This PR add missing removal and translation of the invalid characters to properly sanitize cobbler entries naming.
Import now skips recreating distro profiles if there is no image present at all.

Issues:
- https://github.com/SUSE/spacewalk/issues/29633
- https://bugzilla.suse.com/show_bug.cgi?id=1259137